### PR TITLE
build: have qDebug messages only compile for debug config

### DIFF
--- a/LASSIE/CMakeLists.txt
+++ b/LASSIE/CMakeLists.txt
@@ -63,4 +63,8 @@ endif()
 
 target_compile_definitions(LASSIE PUBLIC "CMOD_BINARY=${CMOD_BINARY}")
 
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(LASSIE PRIVATE QT_NO_DEBUG_OUTPUT)
+endif()
+
 message(STATUS "DONE!")


### PR DESCRIPTION
so, only if CMAKE_BUILD_TYPE=Debug is passed at configuration (i.e., at `cmake [options] ..`)

Default behavior is currently that qDebug messages will always print, which isn't exactly wanted when we're not compiling debug builds. 