### PR TITLE
Store event type as integer, display as readable string

### DIFF
--- a/LASSIE/src/core/event_struct.hpp
+++ b/LASSIE/src/core/event_struct.hpp
@@ -109,6 +109,48 @@ struct ChildDef {
     unsigned durationtype_flag = 0; /* from Childdeftimeflag */
 };
 
+/// Convert an Eventtype enum value to a human-readable display string.
+inline QString eventtypeToDisplayString(int type) {
+    switch (type) {
+        case top:     return "Top";
+        case high:    return "High";
+        case mid:     return "Mid";
+        case low:     return "Low";
+        case bottom:  return "Bottom";
+        case sound:   return "Spectrum";
+        case env:     return "Envelope";
+        case sieve:   return "Sieve";
+        case spa:     return "Spatialization";
+        case pattern: return "Pattern";
+        case reverb:  return "Reverb";
+        case folder:  return "Folder";
+        case note:    return "Note";
+        case filter:  return "Filter";
+        case mea:     return "Measurement";
+        default:      return QString::number(type);
+    }
+}
+
+/// Convert a display string (e.g. "Top", "High") to the integer enum value as a string.
+inline QString displayStringToEventtypeString(const QString& s) {
+    if (s == "Top")             return "0";
+    if (s == "High")            return "1";
+    if (s == "Mid")             return "2";
+    if (s == "Low")             return "3";
+    if (s == "Bottom")          return "4";
+    if (s == "Spectrum")        return "5";
+    if (s == "Envelope")        return "6";
+    if (s == "Sieve")           return "7";
+    if (s == "Spatialization")  return "8";
+    if (s == "Pattern")         return "9";
+    if (s == "Reverb")          return "10";
+    if (s == "Folder")          return "11";
+    if (s == "Note")            return "12";
+    if (s == "Filter")          return "13";
+    if (s == "Measurement")     return "14";
+    return s; // already an integer string or unknown — pass through
+}
+
 typedef struct Package Package;
 struct Package {
     QString event_name;

--- a/LASSIE/src/core/project_struct.cpp
+++ b/LASSIE/src/core/project_struct.cpp
@@ -75,6 +75,11 @@ namespace XercesParser {
 
         DOMElement *type_el = name_el->getNextElementSibling();
         transcodeToQString(type_el, package.event_type);
+        // convert (bad) non-numeric values to their enum value equivalent
+        bool ok;
+        int type_val = package.event_type.toInt(&ok); 
+        if(!ok)
+            package.event_type = displayStringToEventtypeString(package.event_type);
 
         DOMElement *weight_el = type_el->getNextElementSibling();
         transcodeToQString(weight_el, package.weight);

--- a/LASSIE/src/widgets/LayerBox.cpp
+++ b/LASSIE/src/widgets/LayerBox.cpp
@@ -93,7 +93,7 @@ LayerBox::LayerBox(Eventtype eventType, unsigned eventIndex, int layerIndex, QWi
     for (const Package& pkg : layer.discrete_packages) {
         int row = m_model->rowCount();
         auto* rowItem  = new QStandardItem(QString::number(row));
-        auto* typeItem = new QStandardItem(pkg.event_type);
+        auto* typeItem = new QStandardItem(eventtypeToDisplayString(pkg.event_type.toInt()));
         auto* nameItem = new QStandardItem(pkg.event_name);
         rowItem->setFlags(rowItem->flags()   & ~Qt::ItemIsEditable);
         typeItem->setFlags(typeItem->flags() & ~Qt::ItemIsEditable);
@@ -246,7 +246,7 @@ bool LayerBox::eventFilter(QObject* obj, QEvent* event) {
 
             int index = m_model->rowCount();
             auto* rowItem  = new QStandardItem(QString::number(index));
-            auto* typeItem = new QStandardItem(droppedType);
+            auto* typeItem = new QStandardItem(droppedType);  // display string for UI
             auto* nameItem = new QStandardItem(droppedName);
             rowItem->setFlags(rowItem->flags()   & ~Qt::ItemIsEditable);
             typeItem->setFlags(typeItem->flags() & ~Qt::ItemIsEditable);
@@ -262,7 +262,7 @@ bool LayerBox::eventFilter(QObject* obj, QEvent* event) {
             // Write the new package directly into the backend layer
             Package pkg;
             pkg.event_name = droppedName;
-            pkg.event_type = droppedType;
+            pkg.event_type = displayStringToEventtypeString(droppedType);
             getBackendLayer().discrete_packages.append(pkg);
 
             qDebug() << "Added package" << droppedName
@@ -309,7 +309,7 @@ void LayerBox::onPasteClipboard() {
     for (const Package& pkg : m_clipboard) {
         int index = m_model->rowCount();
         auto* rowItem  = new QStandardItem(QString::number(index));
-        auto* typeItem = new QStandardItem(pkg.event_type);
+        auto* typeItem = new QStandardItem(eventtypeToDisplayString(pkg.event_type.toInt()));
         auto* nameItem = new QStandardItem(pkg.event_name);
         rowItem->setFlags(rowItem->flags()   & ~Qt::ItemIsEditable);
         typeItem->setFlags(typeItem->flags() & ~Qt::ItemIsEditable);


### PR DESCRIPTION
## Changes

- Added `eventtypeToDisplayString()` helper function to convert event type enum values to human-readable display strings (e.g., `top` → "Top", `sound` → "Spectrum")
- Added `displayStringToEventtypeInt()` helper function to convert display strings back to integer enum values
- Updated LayerBox to use display strings in the UI while storing integer enum values in the backend
- Modified package initialization and clipboard paste operations to convert between display strings and integer values

## Benefits

- Improves code maintainability by centralizing event type string conversions
- Separates UI representation from data storage
- Makes the codebase more readable with explicit conversion functions