### PR TITLE
Implement MakeFilter deserialization and dbGain button state

### DIFF
--- a/LASSIE/src/dialogs/FunctionGenerator.cpp
+++ b/LASSIE/src/dialogs/FunctionGenerator.cpp
@@ -449,13 +449,13 @@ void FunctionGenerator::setupUi()
         // Parse <Type>
         DOMElement* thisElement = functionNameElement->getNextElementSibling();
         std::string filterType = getFunctionString(thisElement);
-        if (filterType == "LPF") ui->makeFilterLPF->setChecked(true);
-        else if (filterType == "HPF") ui->makeFilterHPF->setChecked(true);
+        if (filterType == "HPF") ui->makeFilterHPF->setChecked(true);
         else if (filterType == "BPF") ui->makeFilterBPF->setChecked(true);
         else if (filterType == "NF") ui->makeFilterNF->setChecked(true);
         else if (filterType == "PBEQF") ui->makeFilterPBEQ->setChecked(true);
         else if (filterType == "LSF") ui->makeFilterLSF->setChecked(true);
         else if (filterType == "HSF") ui->makeFilterHSF->setChecked(true);
+        else ui->makeFilterLPF->setChecked(true); // default case, also if == "LPF"
         // Parse <Frequency>
         thisElement = thisElement->getNextElementSibling();
         ui->makeFilterFrequencyEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
@@ -1289,7 +1289,7 @@ void FunctionGenerator::expandPatternTextChanged(){
 /* MakeFilter Signal Functions */
 void FunctionGenerator::makeFilterFrequencyFunButtonClicked(){
   QString initialText = ui->makeFilterFrequencyEdit->text();
-  FunctionGenerator* generator = new FunctionGenerator(this, functionReturnPAT, initialText);
+  FunctionGenerator* generator = new FunctionGenerator(this, functionReturnFloat, initialText);
   if (generator->exec() == QDialog::Accepted) {
     QString result = generator->getResultString();
     if (!result.isEmpty()) {
@@ -1300,7 +1300,7 @@ void FunctionGenerator::makeFilterFrequencyFunButtonClicked(){
 }
 void FunctionGenerator::makeFilterBandWidthFunButtonClicked(){
   QString initialText = ui->makeFilterBWEdit->text();
-  FunctionGenerator* generator = new FunctionGenerator(this, functionReturnPAT, initialText);
+  FunctionGenerator* generator = new FunctionGenerator(this, functionReturnFloat, initialText);
   if (generator->exec() == QDialog::Accepted) {
     QString result = generator->getResultString();
     if (!result.isEmpty()) {
@@ -1311,7 +1311,7 @@ void FunctionGenerator::makeFilterBandWidthFunButtonClicked(){
 }
 void FunctionGenerator::makeFilterDBGainFunButtonClicked(){
   QString initialText = ui->makeFilterDBEdit->text();
-  FunctionGenerator* generator = new FunctionGenerator(this, functionReturnPAT, initialText);
+  FunctionGenerator* generator = new FunctionGenerator(this, functionReturnFloat, initialText);
   if (generator->exec() == QDialog::Accepted) {
     QString result = generator->getResultString();
     if (!result.isEmpty()) {

--- a/LASSIE/src/dialogs/FunctionGenerator.cpp
+++ b/LASSIE/src/dialogs/FunctionGenerator.cpp
@@ -427,20 +427,44 @@ void FunctionGenerator::setupUi()
         functionName = string(functionNameChars);
         XMLString::release(&functionNameChars);
     }
-    if (functionName == "RandomInt") {
-        int index = -1;
+    // Helper to find and select the combo box item matching the function name
+    auto selectComboItem = [&](const std::string& name) {
         for (int i = 0; i < ui->functionOptions->count(); ++i) {
-            QString itemText = ui->functionOptions->itemText(i);
-            if (itemText.toStdString() == functionName) {
-                index = i;
-                break;
+            if (ui->functionOptions->itemText(i).toStdString() == name) {
+                ui->functionOptions->setCurrentIndex(i);
+                return;
             }
         }
-        if (index != -1) { ui->functionOptions->setCurrentIndex(index); }
+    };
+
+    if (functionName == "RandomInt") {
+        selectComboItem(functionName);
         DOMElement* thisElement = functionNameElement->getNextElementSibling();
         ui->randomIntLowerBoundEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
         thisElement = thisElement->getNextElementSibling();
         ui->randomIntUpperBoundEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+    }
+    else if (functionName == "MakeFilter") {
+        selectComboItem(functionName);
+        // Parse <Type>
+        DOMElement* thisElement = functionNameElement->getNextElementSibling();
+        std::string filterType = getFunctionString(thisElement);
+        if (filterType == "LPF") ui->makeFilterLPF->setChecked(true);
+        else if (filterType == "HPF") ui->makeFilterHPF->setChecked(true);
+        else if (filterType == "BPF") ui->makeFilterBPF->setChecked(true);
+        else if (filterType == "NF") ui->makeFilterNF->setChecked(true);
+        else if (filterType == "PBEQF") ui->makeFilterPBEQ->setChecked(true);
+        else if (filterType == "LSF") ui->makeFilterLSF->setChecked(true);
+        else if (filterType == "HSF") ui->makeFilterHSF->setChecked(true);
+        // Parse <Frequency>
+        thisElement = thisElement->getNextElementSibling();
+        ui->makeFilterFrequencyEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+        // Parse <BandWidth>
+        thisElement = thisElement->getNextElementSibling();
+        ui->makeFilterBWEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+        // Parse <dBGain>
+        thisElement = thisElement->getNextElementSibling();
+        ui->makeFilterDBEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
     }
 }
 
@@ -1302,30 +1326,37 @@ void FunctionGenerator::makeFilterTextChanged(){
     if (ui->makeFilterLPF->isChecked()) {
         stringbuffer = stringbuffer + "LPF";
         ui->makeFilterDBEdit->setEnabled(false);
+        ui->makeFilterDBInsertFn->setEnabled(false);
     }
     if (ui->makeFilterHPF->isChecked()) {
         stringbuffer = stringbuffer + "HPF";
         ui->makeFilterDBEdit->setEnabled(false);
+        ui->makeFilterDBInsertFn->setEnabled(false);
     }
     if (ui->makeFilterBPF->isChecked()) {
         stringbuffer = stringbuffer + "BPF";
         ui->makeFilterDBEdit->setEnabled(false);
+        ui->makeFilterDBInsertFn->setEnabled(false);
     }
     if (ui->makeFilterHSF->isChecked()) {
         stringbuffer = stringbuffer + "HSF";
         ui->makeFilterDBEdit->setEnabled(true);
+        ui->makeFilterDBInsertFn->setEnabled(true);
     }
     if (ui->makeFilterLSF->isChecked()) {
         stringbuffer = stringbuffer + "LSF";
         ui->makeFilterDBEdit->setEnabled(true);
+        ui->makeFilterDBInsertFn->setEnabled(true);
     }
     if (ui->makeFilterNF->isChecked()) {
         stringbuffer = stringbuffer + "NF";
         ui->makeFilterDBEdit->setEnabled(false);
+        ui->makeFilterDBInsertFn->setEnabled(false);
     }
     if (ui->makeFilterPBEQ->isChecked()) {
         stringbuffer = stringbuffer + "PBEQF";
         ui->makeFilterDBEdit->setEnabled(true);
+        ui->makeFilterDBInsertFn->setEnabled(true);
     }
     stringbuffer = stringbuffer +"</Type><Frequency>" + ui->makeFilterFrequencyEdit->text()+ "</Frequency>";
     stringbuffer = stringbuffer +"<BandWidth>" + ui->makeFilterBWEdit->text()+ "</BandWidth>";

--- a/LASSIE/src/widgets/EventAttributesViewController.cpp
+++ b/LASSIE/src/widgets/EventAttributesViewController.cpp
@@ -82,6 +82,8 @@ EventAttributesViewController::EventAttributesViewController(ProjectView* projec
             this, &EventAttributesViewController::attributesStandardRevButtonClicked);
     connect(ui->attributesStandardFilButton, &QPushButton::clicked,
             this, &EventAttributesViewController::attributesStandardFilButtonClicked);
+    connect(ui->filBuilderFunButton, &QPushButton::clicked,
+            this, &EventAttributesViewController::attributesFilBuilderButtonClicked);
     connect(ui->attributesStandardSpaButton, &QPushButton::clicked,
             this, &EventAttributesViewController::attributesStandardSpaButtonClicked);
     connect(ui->BSLoudnessButton, &QPushButton::clicked,
@@ -1200,6 +1202,10 @@ void EventAttributesViewController::attributesStandardFilButtonClicked() {
     insertFunctionString(attributesFilFunButton);
 }
 
+void EventAttributesViewController::attributesFilBuilderButtonClicked() {
+    insertFunctionString(attributesFilBuilderFunButton);
+}
+
 void EventAttributesViewController::attributesStandardSpaButtonClicked() {
     insertFunctionString(attributesSpaFunButton);
 }
@@ -1337,6 +1343,10 @@ void EventAttributesViewController::insertFunctionString(FunctionButton button) 
         break;
     case attributesFilFunButton:
         target = ui->filEntry;
+        gen = new FunctionGenerator(nullptr, functionReturnFIL, target->text());
+        break;
+    case attributesFilBuilderFunButton:
+        target = ui->filBuilderEntry;
         gen = new FunctionGenerator(nullptr, functionReturnFIL, target->text());
         break;
     case BSLoudnessFunButton:

--- a/LASSIE/src/widgets/EventAttributesViewController.hpp
+++ b/LASSIE/src/widgets/EventAttributesViewController.hpp
@@ -39,6 +39,7 @@ typedef enum {
     attributesSpaFunButton,
     attributesRevFunButton,
     attributesFilFunButton,
+    attributesFilBuilderFunButton,
     BSLoudnessFunButton,
     BSModGroupFunButton,
     BSWellTemperedFunButton,
@@ -127,6 +128,7 @@ private slots:
     // // bottom-sub attribute function buttons
     void attributesStandardRevButtonClicked();
     void attributesStandardFilButtonClicked();
+    void attributesFilBuilderButtonClicked();
     void attributesStandardSpaButtonClicked();
     void BSLoudnessButtonClicked();
     // void BSSpatializationButtonClicked();


### PR DESCRIPTION
## Changes

- **Refactor combo box selection**: Extracted common logic into a `selectComboItem` lambda helper to reduce code duplication
- **Add MakeFilter deserialization**: Implement parsing of MakeFilter function parameters from XML:
  - Parse and set filter type (LPF, HPF, BPF, NF, PBEQF, LSF, HSF)
  - Parse and populate frequency, bandwidth, and dB gain input fields
- **Sync dbGain button state**: Update `makeFilterDBInsertFn` button enabled/disabled state to match `makeFilterDBEdit` field state based on filter type selection

## Impact

Users can now properly load and deserialize MakeFilter configurations from saved files, with correct UI state restoration including dB gain field and button visibility.