### PR TITLE
Add deserialization for GetPattern, MakePattern, ExpandPattern

### DIFF
--- a/LASSIE/src/dialogs/FunctionGenerator.cpp
+++ b/LASSIE/src/dialogs/FunctionGenerator.cpp
@@ -592,6 +592,11 @@ void FunctionGenerator::setupUi()
         // <Pattern>
         thisElement = thisElement->getNextElementSibling();
         ui->expandPatternPatternEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+    } else if (functionName == "ReadPATFile") {
+        selectComboItem(functionName);
+        // <File>
+        DOMElement* thisElement = functionNameElement->getNextElementSibling();
+        ui->readPatFileEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
     }
 }
 

--- a/LASSIE/src/dialogs/FunctionGenerator.cpp
+++ b/LASSIE/src/dialogs/FunctionGenerator.cpp
@@ -551,6 +551,47 @@ void FunctionGenerator::setupUi()
 
         thisElement = thisElement->getNextElementSibling(); // <Offsets>
         ui->valuePickOffsetEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+    } else if (functionName == "GetPattern") {
+        selectComboItem(functionName);
+        // <Method>
+        DOMElement* thisElement = functionNameElement->getNextElementSibling();
+        std::string method = getFunctionString(thisElement);
+        if (method == "OTHER") { ui->getPatternMethodOther->setChecked(true); }
+        else if (method == "TYPE_CLUSTERS") { ui->getPatternMethodTypeClusters->setChecked(true); }
+        else if (method == "TIME_DEPEND") { ui->getPatternMethodTimeDepend->setChecked(true); }
+        else if (method == "PROBABILITY") { ui->getPatternMethodProbability->setChecked(true); }
+        else { ui->getPatternMethodInOrder->setChecked(true); } // default / "IN_ORDER"
+        // <Offset>
+        thisElement = thisElement->getNextElementSibling();
+        ui->getPatternOriginEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+        // <Pattern>
+        thisElement = thisElement->getNextElementSibling();
+        ui->getPatternChooseEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+    } else if (functionName == "MakePattern") {
+        selectComboItem(functionName);
+        // <List>
+        DOMElement* thisElement = functionNameElement->getNextElementSibling();
+        ui->makePatternIntervalsEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+    } else if (functionName == "ExpandPattern") {
+        selectComboItem(functionName);
+        // <Method>
+        DOMElement* thisElement = functionNameElement->getNextElementSibling();
+        std::string method = getFunctionString(thisElement);
+        if (method == "SYMMETRIES") { ui->expandPatternMethodSymmetries->setChecked(true); }
+        else if (method == "DISTORT") { ui->expandPatternMethodDistort->setChecked(true); }
+        else { ui->expandPatternMethodEquivalence->setChecked(true); } // default / "EQUIVALENCE"
+        // <Modulo>
+        thisElement = thisElement->getNextElementSibling();
+        ui->expandPatternModuloEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+        // <Low>
+        thisElement = thisElement->getNextElementSibling();
+        ui->expandPatternLowEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+        // <High>
+        thisElement = thisElement->getNextElementSibling();
+        ui->expandPatternHighEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+        // <Pattern>
+        thisElement = thisElement->getNextElementSibling();
+        ui->expandPatternPatternEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
     }
 }
 

--- a/LASSIE/src/dialogs/FunctionGenerator.cpp
+++ b/LASSIE/src/dialogs/FunctionGenerator.cpp
@@ -748,6 +748,7 @@ void FunctionGenerator::handleFunctionChanged(int index)
             break;
         case functionGetPattern:
             currPageIndex = 15;
+            ui->getPatternMethodInOrder->setChecked(true);
             ui->getPatternChooseEdit->setText("PAT");
             getPatternEntryChanged();
             break;
@@ -792,6 +793,7 @@ void FunctionGenerator::handleFunctionChanged(int index)
             break;  
         case functionExpandPattern:
             currPageIndex = 25;
+            ui->expandPatternMethodEquivalence->setChecked(true);
             expandPatternTextChanged();
             break; 
         case functionReadPATFile:


### PR DESCRIPTION
Add XML deserialization support for three function generators in FunctionGenerator::setupUi():

- **GetPattern**: Deserializes method selection (IN_ORDER, OTHER, TYPE_CLUSTERS, TIME_DEPEND, PROBABILITY), origin offset, and pattern choice
- **MakePattern**: Deserializes intervals list parameter
- **ExpandPattern**: Deserializes method selection (EQUIVALENCE, SYMMETRIES, DISTORT), modulo value, low/high bounds, and pattern

Each function properly extracts XML elements and populates corresponding UI controls.