### PR TITLE
FunctionGenerator: add deserialization for ReadSIVFile, ReadENVFile, ReadFILFile, ChooseL, EnvLib

### DIFF
--- a/LASSIE/src/dialogs/FunctionGenerator.cpp
+++ b/LASSIE/src/dialogs/FunctionGenerator.cpp
@@ -597,6 +597,34 @@ void FunctionGenerator::setupUi()
         // <File>
         DOMElement* thisElement = functionNameElement->getNextElementSibling();
         ui->readPatFileEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+    } else if (functionName == "ReadSIVFile") {
+        selectComboItem(functionName);
+        // <File>
+        DOMElement* thisElement = functionNameElement->getNextElementSibling();
+        ui->readSivFileEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+    } else if (functionName == "ReadENVFile") {
+        selectComboItem(functionName);
+        // <File>
+        DOMElement* thisElement = functionNameElement->getNextElementSibling();
+        ui->readEnvFileEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+    } else if (functionName == "ReadFILFile") {
+        selectComboItem(functionName);
+        // <File>
+        DOMElement* thisElement = functionNameElement->getNextElementSibling();
+        ui->readFilFileEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+    } else if (functionName == "ChooseL") {
+        selectComboItem(functionName);
+        // <Entry>
+        DOMElement* thisElement = functionNameElement->getNextElementSibling();
+        ui->chooseLEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+    } else if (functionName == "EnvLib") {
+        selectComboItem(functionName);
+        // <Env>
+        DOMElement* thisElement = functionNameElement->getNextElementSibling();
+        ui->envLibNumEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+        // <Scale>
+        thisElement = thisElement->getNextElementSibling();
+        ui->envLibScalingEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds five missing `else if` deserialization cases to the `FunctionGenerator` constructor (the XML parsing block that pre-populates UI fields when reopening a saved function)
- Affected functions: `ReadSIVFile`, `ReadENVFile`, `ReadFILFile`, `ChooseL`, `EnvLib`
- Each case calls `selectComboItem` to restore the combo box selection, then walks the XML siblings to restore field values — matching the pattern established by `ReadPATFile`, `GetPattern`, `MakePattern`, etc.

## Why

All five functions were fully wired up (combo box entries, `handleFunctionChanged` switch cases, serialization signal handlers) but had no deserialization path. Reopening a project that used any of these function types would open the dialog with all fields blank instead of showing the saved values.

## Test plan

- [ ] Build succeeds with no new compile errors
- [ ] In LASSIE, configure a node field using each of the five function types, save the project, reopen it, and verify the FunctionGenerator dialog shows the previously entered values

🤖 Generated with [Claude Code](https://claude.com/claude-code)