### PR TITLE
use qt's built-in modified window function

### DIFF
--- a/LASSIE/src/utilities.hpp
+++ b/LASSIE/src/utilities.hpp
@@ -7,11 +7,9 @@
    e.g., Nhi's MarkovModel methods should go into ProjectManager in place of direct reference access to the QList<MarkovModel<float>> */
 namespace MUtilities {
 
-    /* Function called when project modified to change the MainWindow title to unsaved version
-    which alerts the user to save the project */
+    /* Function called when project modified to mark the window as having unsaved changes */
     inline void modified(){
-        ProjectManager *pm = Inst::get_project_manager();
-        MainWindow::instance()->setUnsavedTitle(pm->fileinfo().absoluteFilePath());
+        MainWindow::instance()->setWindowModified(true);
     }
 
 }

--- a/LASSIE/src/windows/MainWindow.cpp
+++ b/LASSIE/src/windows/MainWindow.cpp
@@ -113,8 +113,7 @@ void MainWindow::closeCurrentProject()
     openAct->setEnabled(true);
     newAct->setEnabled(true);
 
-    currentFile = QString();
-    setWindowTitle(tr("LASSIE"));
+    setCurrentFile(QString(), false);
 }
 
 void MainWindow::newFile()
@@ -136,7 +135,7 @@ void MainWindow::newFile()
     const QString fullFilePath = projectFolder + "/" + projectName + ".dissco";
     currentFile = fullFilePath;
 
-    setUnsavedTitle(currentFile);
+    setCurrentFile(currentFile, true);
     Inst::get_project_manager()->build(currentFile, nullptr);
     showFile();
 }
@@ -185,7 +184,7 @@ void MainWindow::saveFile()
     projectView->save();
     
     //nhi: update window title and status after successful save
-    setWindowTitle(tr("%1 - %2").arg(currentFile, tr("LASSIE")));
+    setWindowModified(false);
     statusBar()->showMessage(tr("File saved"), 2000);
 }
 
@@ -474,7 +473,7 @@ void MainWindow::showFile()
         if(projectView == nullptr){
             projectView = new ProjectView(this, currentFile);
 
-            setWindowTitle(tr("%1 - %2").arg(currentFile, tr("LASSIE")));
+            setCurrentFile(currentFile, false);
             statusBar()->showMessage(tr("Project loaded"), 2000);
             projectView->setProperties();
 
@@ -492,8 +491,11 @@ void MainWindow::showFile()
     }
 }
 
-void MainWindow::setUnsavedTitle(const QString &unsavedFile){
-    currentFile = unsavedFile;
-    setWindowTitle(tr("%1 - %2").arg("*" + currentFile, tr("LASSIE")));
-    qDebug() << "*currentFile: " << currentFile;
+void MainWindow::setCurrentFile(const QString &file, bool modified){
+    currentFile = file;
+    if (currentFile.isEmpty())
+        setWindowTitle(tr("LASSIE"));
+    else
+        setWindowTitle(tr("%1[*] - %2").arg(currentFile, tr("LASSIE")));
+    setWindowModified(modified);
 }

--- a/LASSIE/src/windows/MainWindow.hpp
+++ b/LASSIE/src/windows/MainWindow.hpp
@@ -23,7 +23,7 @@ class MainWindow : public QMainWindow
         explicit MainWindow(Inst*);
         static MainWindow* instance() { return instance_; }
         ~MainWindow() override;
-        void setUnsavedTitle(const QString &unsavedFile);
+        void setCurrentFile(const QString &file, bool modified = false);
 
         std::unique_ptr<Ui::MainWindow> ui;
         std::unique_ptr<EnvelopeLibraryWindow> envelopeLibraryWindow;


### PR DESCRIPTION
Just attempts to standardize the window behavior when modifications happen (so, when '*' would normally be added). This also enables platform-specific behavior for macOS (the unsaved 'dot').