### PR TITLE
display branch that lassie was compiled on in About

### DIFF
--- a/LASSIE/CMakeLists.txt
+++ b/LASSIE/CMakeLists.txt
@@ -67,6 +67,18 @@ endif()
 
 target_compile_definitions(LASSIE PUBLIC "CMOD_BINARY=${CMOD_BINARY}")
 
+execute_process(
+    COMMAND git rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_BRANCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+if(NOT GIT_BRANCH)
+    set(GIT_BRANCH "unknown")
+endif()
+target_compile_definitions(LASSIE PRIVATE "GIT_BRANCH=\"${GIT_BRANCH}\"")
+
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_definitions(LASSIE PRIVATE QT_NO_DEBUG_OUTPUT)
 endif()

--- a/LASSIE/CMakeLists.txt
+++ b/LASSIE/CMakeLists.txt
@@ -65,7 +65,7 @@ if(QT_VERSION_MAJOR EQUAL 6)
     qt_finalize_executable(LASSIE)
 endif()
 
-target_compile_definitions(LASSIE PUBLIC "CMOD_BINARY=${CMOD_BINARY}")
+target_compile_definitions(LASSIE PUBLIC "CMOD_BINARY=\"${CMOD_BINARY}\"")
 
 execute_process(
     COMMAND git rev-parse --abbrev-ref HEAD

--- a/LASSIE/src/windows/MainWindow.cpp
+++ b/LASSIE/src/windows/MainWindow.cpp
@@ -393,7 +393,8 @@ void MainWindow::createActions()
     connect(aboutAct, &QAction::triggered, this, [this]() {
         QMessageBox::about(this, tr("About LASSIE"),
             tr("LASSIE (Library for Algorithmic Sound Synthesis and Interactive Exploration) "
-               "is a tool for creating and manipulating sound synthesis algorithms."));
+               "is a tool for creating and manipulating sound synthesis algorithms.\n\n"
+               "Branch: ") + GIT_BRANCH);
     });
 
     aboutQtAct = new QAction(tr("About &Qt"), this);

--- a/LASSIE/src/windows/MainWindow.cpp
+++ b/LASSIE/src/windows/MainWindow.cpp
@@ -260,11 +260,6 @@ void MainWindow::runProject()
 
     using namespace Qt::StringLiterals;
 
-#define STR_VALUE(arg)      #arg
-#define FUNCTION_NAME(name) STR_VALUE(name)
-
-#define LASSIE_CMOD_BINARY__ FUNCTION_NAME(CMOD_BINARY)
-
     const auto cmod = new QProcess(this);
     connect(cmod, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), 
             [=](const int exit_code)
@@ -272,13 +267,13 @@ void MainWindow::runProject()
                 statusBar()->showMessage(tr("CMOD exited with code %1").arg(exit_code)); 
             }
         );
-    qDebug() << "Project run with string:" << QString(LASSIE_CMOD_BINARY__) + " " + pm->fileinfo().canonicalFilePath();
+    qDebug() << "Project run with string:" << QString(CMOD_BINARY) + " " + pm->fileinfo().canonicalFilePath();
 
     const auto pw = new PostWindow(cmod);
     pw->resize(600,400);
     pw->show();
 
-    cmod->start(QString(LASSIE_CMOD_BINARY__), QStringList() << pm->fileinfo().canonicalFilePath());
+    cmod->start(QString(CMOD_BINARY), QStringList() << pm->fileinfo().canonicalFilePath());
 }
 
 void MainWindow::readSettings()


### PR DESCRIPTION
### Motivation
I kept opening several LASSIE windows and had to manually keep track of which binaries were built off which branches, which became a bit tiring/uncertain. 

### Changes

- Runs `git rev-parse` to get the current branch, injects it into the program as a stringified preprocessor macro (i.e., `std::string`)
- Adds branch name to About LASSIE text
- Similarly stringifies `CMOD_BINARY` preprocessor macro in CMakeList so that src files may simply refer to `CMOD_BINARY` without need to stringify it (I see no reason, currently, that we'd want the raw, un-stringified pathname) 
