### PR TITLE
reimplement markov window and row as QTableView

### DIFF
--- a/LASSIE/src/windows/MainWindow.cpp
+++ b/LASSIE/src/windows/MainWindow.cpp
@@ -214,7 +214,15 @@ void MainWindow::showEnvelopeLibraryWindow() const {
 }
 
 void MainWindow::showMarkovWindow() const {
-    //nhi: use show() instead of showMarkovLibrary()
+    // If the window is already open, just bring it to the front / refocus it
+    // instead of re-running setActiveProject (which would discard the current
+    // editor state, undo history, and selection).
+    if (markovWindow->isVisible()) {
+        markovWindow->raise();
+        markovWindow->activateWindow();
+        return;
+    }
+
     markovWindow->show();
     if (projectView) {
         markovWindow->setActiveProject(projectView);

--- a/LASSIE/src/windows/MarkovModelLibraryWindow.cpp
+++ b/LASSIE/src/windows/MarkovModelLibraryWindow.cpp
@@ -151,7 +151,7 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
 
     // --- Left panel: model list ---------------------------------------------
     m_listModel = new QStandardItemModel(this);
-    m_listModel->setHorizontalHeaderLabels({tr("Id")});
+    m_listModel->setHorizontalHeaderLabels({tr("id")});
 
     m_treeView = new QTreeView;
     m_treeView->setModel(m_listModel);
@@ -255,6 +255,7 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
     m_rightStack->setCurrentIndex(m_emptyPageIndex);
 
     splitter->addWidget(m_rightStack);
+    splitter->setCollapsible(1, false); // prevent collapsing the markov window view
     splitter->setStretchFactor(0, 0);
     splitter->setStretchFactor(1, 1);
     splitter->setSizes({160, 740});

--- a/LASSIE/src/windows/MarkovModelLibraryWindow.cpp
+++ b/LASSIE/src/windows/MarkovModelLibraryWindow.cpp
@@ -21,6 +21,7 @@
 #include <QPushButton>
 #include <QRegularExpression>
 #include <QSplitter>
+#include <QStackedWidget>
 #include <QStandardItem>
 #include <QStandardItemModel>
 #include <QUndoCommand>
@@ -162,7 +163,22 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
     m_treeView->header()->setStretchLastSection(true);
     splitter->addWidget(m_treeView);
 
-    // --- Right panel: editor ------------------------------------------------
+    // --- Right panel: stacked (empty placeholder + editor) -----------------
+    m_rightStack = new QStackedWidget;
+
+    // Empty page: a single centered message shown when no model is selected.
+    auto* emptyPage = new QWidget;
+    auto* emptyLayout = new QVBoxLayout(emptyPage);
+    emptyLayout->setContentsMargins(0, 0, 0, 0);
+    auto* emptyLabel = new QLabel(
+        tr("Select (or create) a Markov library from the list on the left"));
+    emptyLabel->setAlignment(Qt::AlignCenter);
+    emptyLabel->setWordWrap(true);
+    emptyLabel->setEnabled(false);  // muted look
+    emptyLayout->addWidget(emptyLabel);
+    m_emptyPageIndex = m_rightStack->addWidget(emptyPage);
+
+    // Editor page
     auto* rightPanel = new QWidget;
     auto* rightLayout = new QVBoxLayout(rightPanel);
     rightLayout->setContentsMargins(8, 8, 8, 8);
@@ -235,7 +251,10 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
     matrixGroupLayout->addWidget(m_matrixView);
     rightLayout->addWidget(matrixGroup, /*stretch=*/1);
 
-    splitter->addWidget(rightPanel);
+    m_editorPageIndex = m_rightStack->addWidget(rightPanel);
+    m_rightStack->setCurrentIndex(m_emptyPageIndex);
+
+    splitter->addWidget(m_rightStack);
     splitter->setStretchFactor(0, 0);
     splitter->setStretchFactor(1, 1);
     splitter->setSizes({160, 740});
@@ -251,8 +270,12 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
     updateContextMenuEnablement();
 
     // --- Signal wiring ------------------------------------------------------
-    connect(m_treeView->selectionModel(), &QItemSelectionModel::currentChanged,
-            this, &MarkovModelLibraryWindow::onSelectionChanged);
+    // selectionChanged (not currentChanged) — fires *after* Qt applies the
+    // selection, so hasSelection()/selectedRows() reflect the real state.
+    // currentChanged also fires when a focused tree view auto-assigns a
+    // currentIndex with no actual selection, which we don't want to react to.
+    connect(m_treeView->selectionModel(), &QItemSelectionModel::selectionChanged,
+            this, [this]{ onSelectionChanged(); });
     connect(m_treeView, &QTreeView::customContextMenuRequested,
             this, &MarkovModelLibraryWindow::onRightClick);
     connect(m_sizeButton, &QPushButton::clicked,
@@ -280,6 +303,7 @@ void MarkovModelLibraryWindow::setActiveProject(ProjectView* project) {
     m_sizeEntry->clear();
     resizeTables(0);
     m_undoStack->clear();
+    m_rightStack->setCurrentIndex(m_emptyPageIndex);
     rebuildModelList();
     updateContextMenuEnablement();
 }
@@ -401,20 +425,27 @@ void MarkovModelLibraryWindow::saveEditorIntoModel(int modelIdx) {
     MUtilities::modified();
 }
 
-void MarkovModelLibraryWindow::onSelectionChanged(const QModelIndex& current,
-                                                  const QModelIndex& previous) {
-    if (previous.isValid()) {
-        saveEditorIntoModel(previous.row());
+void MarkovModelLibraryWindow::onSelectionChanged() {
+    // Save whatever model was previously loaded into the editor.
+    const int previousRow = currentSelection;
+    if (previousRow >= 0) {
+        saveEditorIntoModel(previousRow);
     }
+
     // Undo history is specific to one model's editor session. Discard it.
     m_undoStack->clear();
-    if (current.isValid()) {
-        currentSelection = current.row();
+
+    const QModelIndexList selected =
+        m_treeView->selectionModel()->selectedRows();
+    if (!selected.isEmpty()) {
+        currentSelection = selected.first().row();
         loadModelIntoEditor(currentSelection);
+        m_rightStack->setCurrentIndex(m_editorPageIndex);
     } else {
         currentSelection = -1;
         resizeTables(0);
         m_sizeEntry->clear();
+        m_rightStack->setCurrentIndex(m_emptyPageIndex);
     }
     updateContextMenuEnablement();
 }
@@ -528,6 +559,8 @@ void MarkovModelLibraryWindow::removeModel() {
     } else {
         resizeTables(0);
         m_sizeEntry->clear();
+        m_rightStack->setCurrentIndex(m_emptyPageIndex);
+        m_undoStack->clear();
         updateContextMenuEnablement();
     }
 }

--- a/LASSIE/src/windows/MarkovModelLibraryWindow.cpp
+++ b/LASSIE/src/windows/MarkovModelLibraryWindow.cpp
@@ -2,7 +2,7 @@
 
 #include <QAction>
 #include <QCloseEvent>
-#include <QGridLayout>
+#include <QDoubleValidator>
 #include <QGroupBox>
 #include <QHBoxLayout>
 #include <QHeaderView>
@@ -10,14 +10,20 @@
 #include <QIntValidator>
 #include <QLabel>
 #include <QLineEdit>
+#include <QLocale>
 #include <QMenu>
 #include <QPushButton>
-#include <QScrollArea>
 #include <QSplitter>
+#include <QStandardItem>
 #include <QStandardItemModel>
+#include <QStringList>
+#include <QStyledItemDelegate>
+#include <QTableView>
 #include <QTreeView>
 #include <QVBoxLayout>
 #include <QWidget>
+
+#include <limits>
 
 #include <algorithm>
 
@@ -27,36 +33,69 @@
 
 namespace {
 
-QWidget* makeGridHost() {
-    auto* host = new QWidget;
-    auto* layout = new QGridLayout(host);
-    layout->setContentsMargins(4, 4, 4, 4);
-    layout->setHorizontalSpacing(6);
-    layout->setVerticalSpacing(4);
-    return host;
-}
+// Item delegate restricting input to nonnegative real numbers (ints/doubles).
+class NonNegativeRealDelegate : public QStyledItemDelegate {
+public:
+    using QStyledItemDelegate::QStyledItemDelegate;
 
-void clearGrid(QWidget* host) {
-    if (auto* old = host->layout()) {
-        QLayoutItem* item;
-        while ((item = old->takeAt(0)) != nullptr) {
-            if (QWidget* w = item->widget()) {
-                w->deleteLater();
-            }
-            delete item;
-        }
-        delete old;
+    QWidget* createEditor(QWidget* parent,
+                          const QStyleOptionViewItem& /*option*/,
+                          const QModelIndex& /*index*/) const override {
+        auto* editor = new QLineEdit(parent);
+        auto* validator = new QDoubleValidator(
+            0.0, std::numeric_limits<double>::max(), 12, editor);
+        validator->setNotation(QDoubleValidator::StandardNotation);
+        // Use C locale so '.' is always the decimal separator.
+        QLocale c(QLocale::C);
+        c.setNumberOptions(QLocale::RejectGroupSeparator);
+        validator->setLocale(c);
+        editor->setValidator(validator);
+
+        // Commit on every keystroke (not just focus-out / Enter) so that a
+        // partially-typed value like ".1" is pushed into the model — and
+        // therefore into the underlying MarkovModel — even if the user
+        // triggers a project save without leaving the cell.
+        connect(editor, &QLineEdit::textEdited, this,
+                [this, editor](const QString&) {
+                    const_cast<NonNegativeRealDelegate*>(this)
+                        ->emitCommitData(editor);
+                });
+        return editor;
     }
-    auto* layout = new QGridLayout(host);
-    layout->setContentsMargins(4, 4, 4, 4);
-    layout->setHorizontalSpacing(6);
-    layout->setVerticalSpacing(4);
+
+    void emitCommitData(QWidget* editor) { emit commitData(editor); }
+
+    void setModelData(QWidget* editor,
+                      QAbstractItemModel* model,
+                      const QModelIndex& index) const override {
+        auto* le = qobject_cast<QLineEdit*>(editor);
+        if (!le) return;
+        const QString text = le->text().trimmed();
+        if (text.isEmpty()) {
+            model->setData(index, QStringLiteral("0"), Qt::EditRole);
+            return;
+        }
+        bool ok = false;
+        const double v = QLocale::c().toDouble(text, &ok);
+        if (!ok || v < 0.0) {
+            // Reject: leave existing model value unchanged.
+            return;
+        }
+        model->setData(index, text, Qt::EditRole);
+    }
+};
+
+QStringList numberedHeaders(int n) {
+    QStringList out;
+    out.reserve(n);
+    for (int i = 0; i < n; ++i) out << QString::number(i + 1);
+    return out;
 }
 
-QLabel* headerLabel(int n) {
-    auto* l = new QLabel(QString::number(n));
-    l->setAlignment(Qt::AlignCenter);
-    return l;
+int rowHeightFor(const QTableView* v) {
+    return v->verticalHeader()->defaultSectionSize()
+         + v->horizontalHeader()->height()
+         + 2 * v->frameWidth();
 }
 
 }  // namespace
@@ -103,45 +142,53 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
     sizeRow->addStretch(1);
     rightLayout->addLayout(sizeRow);
 
-    // Initial distribution group
+    auto* delegate = new NonNegativeRealDelegate(this);
+
+    // Initial distribution
+    m_distModel = new QStandardItemModel(this);
+    m_distView = new QTableView;
+    m_distView->setModel(m_distModel);
+    m_distView->setItemDelegate(delegate);
+    m_distView->verticalHeader()->setVisible(false);
+    m_distView->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
+    m_distView->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_distView->setFixedHeight(rowHeightFor(m_distView) + m_distView->verticalHeader()->defaultSectionSize());
+
     auto* distGroup = new QGroupBox(tr("Initial Distribution"));
     auto* distGroupLayout = new QVBoxLayout(distGroup);
     distGroupLayout->setContentsMargins(6, 6, 6, 6);
-    auto* distScroll = new QScrollArea;
-    distScroll->setWidgetResizable(true);
-    distScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    distScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    distScroll->setFixedHeight(90);
-    m_distGridHost = makeGridHost();
-    distScroll->setWidget(m_distGridHost);
-    distGroupLayout->addWidget(distScroll);
+    distGroupLayout->addWidget(m_distView);
     rightLayout->addWidget(distGroup);
 
-    // Values-for-states group
+    // Values for states
+    m_valueModel = new QStandardItemModel(this);
+    m_valueView = new QTableView;
+    m_valueView->setModel(m_valueModel);
+    m_valueView->setItemDelegate(delegate);
+    m_valueView->verticalHeader()->setVisible(false);
+    m_valueView->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
+    m_valueView->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_valueView->setFixedHeight(rowHeightFor(m_valueView) + m_valueView->verticalHeader()->defaultSectionSize());
+
     auto* valueGroup = new QGroupBox(tr("Values for states"));
     auto* valueGroupLayout = new QVBoxLayout(valueGroup);
     valueGroupLayout->setContentsMargins(6, 6, 6, 6);
-    auto* valueScroll = new QScrollArea;
-    valueScroll->setWidgetResizable(true);
-    valueScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    valueScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    valueScroll->setFixedHeight(90);
-    m_valueGridHost = makeGridHost();
-    valueScroll->setWidget(m_valueGridHost);
-    valueGroupLayout->addWidget(valueScroll);
+    valueGroupLayout->addWidget(m_valueView);
     rightLayout->addWidget(valueGroup);
 
-    // Transition matrix group
+    // Transition matrix
+    m_matrixModel = new QStandardItemModel(this);
+    m_matrixView = new QTableView;
+    m_matrixView->setModel(m_matrixModel);
+    m_matrixView->setItemDelegate(delegate);
+    m_matrixView->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
+    m_matrixView->verticalHeader()->setSectionResizeMode(QHeaderView::Interactive);
+    m_matrixView->setSelectionMode(QAbstractItemView::SingleSelection);
+
     auto* matrixGroup = new QGroupBox(tr("Transition Matrix"));
     auto* matrixGroupLayout = new QVBoxLayout(matrixGroup);
     matrixGroupLayout->setContentsMargins(6, 6, 6, 6);
-    auto* matrixScroll = new QScrollArea;
-    matrixScroll->setWidgetResizable(true);
-    matrixScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    matrixScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    m_matrixGridHost = makeGridHost();
-    matrixScroll->setWidget(m_matrixGridHost);
-    matrixGroupLayout->addWidget(matrixScroll);
+    matrixGroupLayout->addWidget(m_matrixView);
     rightLayout->addWidget(matrixGroup, /*stretch=*/1);
 
     splitter->addWidget(rightPanel);
@@ -168,6 +215,12 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
             this, &MarkovModelLibraryWindow::onSetSize);
     connect(m_sizeEntry, &QLineEdit::returnPressed,
             this, &MarkovModelLibraryWindow::onSetSize);
+    connect(m_distModel, &QStandardItemModel::itemChanged,
+            this, &MarkovModelLibraryWindow::onItemChanged);
+    connect(m_valueModel, &QStandardItemModel::itemChanged,
+            this, &MarkovModelLibraryWindow::onItemChanged);
+    connect(m_matrixModel, &QStandardItemModel::itemChanged,
+            this, &MarkovModelLibraryWindow::onItemChanged);
 }
 
 MarkovModelLibraryWindow::~MarkovModelLibraryWindow() = default;
@@ -177,7 +230,7 @@ void MarkovModelLibraryWindow::setActiveProject(ProjectView* project) {
     currentSelection = -1;
     currentSize = 0;
     m_sizeEntry->clear();
-    rebuildEditorGrid(0);
+    resizeTables(0);
     rebuildModelList();
     updateContextMenuEnablement();
 }
@@ -209,61 +262,29 @@ void MarkovModelLibraryWindow::rebuildModelList() {
     }
 }
 
-void MarkovModelLibraryWindow::rebuildEditorGrid(int size) {
-    m_distEntries.clear();
-    m_valueEntries.clear();
-    m_matrixEntries.clear();
+void MarkovModelLibraryWindow::resizeTables(int size) {
+    suppressItemChanged = true;
 
-    clearGrid(m_distGridHost);
-    clearGrid(m_valueGridHost);
-    clearGrid(m_matrixGridHost);
+    const QStringList headers = numberedHeaders(size);
+
+    m_distModel->clear();
+    m_distModel->setRowCount(size > 0 ? 1 : 0);
+    m_distModel->setColumnCount(size);
+    m_distModel->setHorizontalHeaderLabels(headers);
+
+    m_valueModel->clear();
+    m_valueModel->setRowCount(size > 0 ? 1 : 0);
+    m_valueModel->setColumnCount(size);
+    m_valueModel->setHorizontalHeaderLabels(headers);
+
+    m_matrixModel->clear();
+    m_matrixModel->setRowCount(size);
+    m_matrixModel->setColumnCount(size);
+    m_matrixModel->setHorizontalHeaderLabels(headers);
+    m_matrixModel->setVerticalHeaderLabels(headers);
 
     currentSize = size;
-    if (size <= 0) return;
-
-    auto* distLayout = static_cast<QGridLayout*>(m_distGridHost->layout());
-    for (int j = 0; j < size; ++j) {
-        distLayout->addWidget(headerLabel(j + 1), 0, j);
-    }
-    for (int j = 0; j < size; ++j) {
-        auto* le = new QLineEdit;
-        le->setMinimumWidth(60);
-        connect(le, &QLineEdit::editingFinished,
-                this, &MarkovModelLibraryWindow::onEntryEdited);
-        distLayout->addWidget(le, 1, j);
-        m_distEntries.push_back(le);
-    }
-
-    auto* valueLayout = static_cast<QGridLayout*>(m_valueGridHost->layout());
-    for (int j = 0; j < size; ++j) {
-        valueLayout->addWidget(headerLabel(j + 1), 0, j);
-    }
-    for (int j = 0; j < size; ++j) {
-        auto* le = new QLineEdit;
-        le->setMinimumWidth(60);
-        connect(le, &QLineEdit::editingFinished,
-                this, &MarkovModelLibraryWindow::onEntryEdited);
-        valueLayout->addWidget(le, 1, j);
-        m_valueEntries.push_back(le);
-    }
-
-    auto* matrixLayout = static_cast<QGridLayout*>(m_matrixGridHost->layout());
-    for (int j = 0; j < size; ++j) {
-        matrixLayout->addWidget(headerLabel(j + 1), 0, j + 1);
-    }
-    for (int i = 0; i < size; ++i) {
-        matrixLayout->addWidget(headerLabel(i + 1), i + 1, 0);
-    }
-    for (int i = 0; i < size; ++i) {
-        for (int j = 0; j < size; ++j) {
-            auto* le = new QLineEdit;
-            le->setMinimumWidth(60);
-            connect(le, &QLineEdit::editingFinished,
-                    this, &MarkovModelLibraryWindow::onEntryEdited);
-            matrixLayout->addWidget(le, i + 1, j + 1);
-            m_matrixEntries.push_back(le);
-        }
-    }
+    suppressItemChanged = false;
 }
 
 void MarkovModelLibraryWindow::loadModelIntoEditor(int modelIdx) {
@@ -276,35 +297,45 @@ void MarkovModelLibraryWindow::loadModelIntoEditor(int modelIdx) {
     auto& model = models[modelIdx];
     const int size = model.getStateSize();
 
-    if (size != currentSize) {
-        rebuildEditorGrid(size);
-    }
+    resizeTables(size);
     m_sizeEntry->setText(QString::number(size));
 
-    for (int i = 0; i < size; ++i) {
-        m_distEntries[i]->setText(QString::number(model.getInitialProbability(i)));
-        m_valueEntries[i]->setText(QString::number(model.getStateValue(i)));
+    suppressItemChanged = true;
+    for (int j = 0; j < size; ++j) {
+        m_distModel->setItem(0, j,
+            new QStandardItem(QString::number(model.getInitialProbability(j))));
+        m_valueModel->setItem(0, j,
+            new QStandardItem(QString::number(model.getStateValue(j))));
     }
     for (int i = 0; i < size; ++i) {
         for (int j = 0; j < size; ++j) {
-            m_matrixEntries[i * size + j]
-                ->setText(QString::number(model.getTransitionProbability(i, j)));
+            m_matrixModel->setItem(i, j,
+                new QStandardItem(QString::number(model.getTransitionProbability(i, j))));
         }
     }
+    suppressItemChanged = false;
 }
 
 QString MarkovModelLibraryWindow::serializeEditor() const {
+
+    auto cell = [](QStandardItem* it) -> QString {
+        if (!it || it->text().isEmpty()) return QStringLiteral("0");
+        return it->text();
+    };
+
     QString s = QString::number(currentSize) + "\n";
-    for (auto* e : m_valueEntries) {
-        s += (e->text().isEmpty() ? QStringLiteral("0") : e->text()) + " ";
+    for (int j = 0; j < currentSize; ++j) {
+        s += cell(m_valueModel->item(0, j)) + " ";
     }
     s += "\n";
-    for (auto* e : m_distEntries) {
-        s += (e->text().isEmpty() ? QStringLiteral("0") : e->text()) + " ";
+    for (int j = 0; j < currentSize; ++j) {
+        s += cell(m_distModel->item(0, j)) + " ";
     }
     s += "\n";
-    for (auto* e : m_matrixEntries) {
-        s += (e->text().isEmpty() ? QStringLiteral("0") : e->text()) + " ";
+    for (int i = 0; i < currentSize; ++i) {
+        for (int j = 0; j < currentSize; ++j) {
+            s += cell(m_matrixModel->item(i, j)) + " ";
+        }
     }
     return s;
 }
@@ -331,7 +362,7 @@ void MarkovModelLibraryWindow::onSelectionChanged(const QModelIndex& current,
         loadModelIntoEditor(currentSelection);
     } else {
         currentSelection = -1;
-        rebuildEditorGrid(0);
+        resizeTables(0);
         m_sizeEntry->clear();
     }
     updateContextMenuEnablement();
@@ -348,43 +379,42 @@ void MarkovModelLibraryWindow::onSetSize() {
     if (!ok || newSize <= 0) return;
     if (newSize == currentSize) return;
 
-    QVector<QString> oldVals = [this]{
-        QVector<QString> v;
-        for (auto* e : m_valueEntries) v.push_back(e->text());
-        return v;
-    }();
-    QVector<QString> oldDists = [this]{
-        QVector<QString> v;
-        for (auto* e : m_distEntries) v.push_back(e->text());
-        return v;
-    }();
     const int oldSize = currentSize;
+    QVector<QString> oldVals(oldSize);
+    QVector<QString> oldDists(oldSize);
     QVector<QVector<QString>> oldMat(oldSize, QVector<QString>(oldSize));
+    for (int j = 0; j < oldSize; ++j) {
+        if (auto* it = m_valueModel->item(0, j)) oldVals[j] = it->text();
+        if (auto* it = m_distModel->item(0, j)) oldDists[j] = it->text();
+    }
     for (int i = 0; i < oldSize; ++i) {
         for (int j = 0; j < oldSize; ++j) {
-            oldMat[i][j] = m_matrixEntries[i * oldSize + j]->text();
+            if (auto* it = m_matrixModel->item(i, j)) oldMat[i][j] = it->text();
         }
     }
 
-    rebuildEditorGrid(newSize);
+    resizeTables(newSize);
 
+    suppressItemChanged = true;
     const int overlap = std::min(oldSize, newSize);
-    for (int i = 0; i < overlap; ++i) {
-        m_valueEntries[i]->setText(oldVals[i]);
-        m_distEntries[i]->setText(oldDists[i]);
+    for (int j = 0; j < overlap; ++j) {
+        m_valueModel->setItem(0, j, new QStandardItem(oldVals[j]));
+        m_distModel->setItem(0, j, new QStandardItem(oldDists[j]));
     }
     for (int i = 0; i < overlap; ++i) {
         for (int j = 0; j < overlap; ++j) {
-            m_matrixEntries[i * newSize + j]->setText(oldMat[i][j]);
+            m_matrixModel->setItem(i, j, new QStandardItem(oldMat[i][j]));
         }
     }
+    suppressItemChanged = false;
 
     if (currentSelection >= 0) {
         saveEditorIntoModel(currentSelection);
     }
 }
 
-void MarkovModelLibraryWindow::onEntryEdited() {
+void MarkovModelLibraryWindow::onItemChanged(QStandardItem* /*item*/) {
+    if (suppressItemChanged) return;
     if (currentSelection >= 0) {
         saveEditorIntoModel(currentSelection);
     }
@@ -399,7 +429,7 @@ void MarkovModelLibraryWindow::createNewModel() {
         saveEditorIntoModel(currentSelection);
     }
 
-    pm->markovmodels().append(MarkovModel<float>()); 
+    pm->markovmodels().append(MarkovModel<float>());
     MUtilities::modified();
 
     rebuildModelList();
@@ -415,7 +445,7 @@ void MarkovModelLibraryWindow::duplicateModel() {
     saveEditorIntoModel(currentSelection);
 
     if (currentSelection < pm->markovmodels().size())
-        pm->markovmodels().append(pm->markovmodels()[currentSelection]); 
+        pm->markovmodels().append(pm->markovmodels()[currentSelection]);
     MUtilities::modified();
 
     rebuildModelList();
@@ -441,7 +471,7 @@ void MarkovModelLibraryWindow::removeModel() {
         const int nextRow = std::min(removed, remaining - 1);
         m_treeView->setCurrentIndex(m_listModel->index(nextRow, 0));
     } else {
-        rebuildEditorGrid(0);
+        resizeTables(0);
         m_sizeEntry->clear();
         updateContextMenuEnablement();
     }

--- a/LASSIE/src/windows/MarkovModelLibraryWindow.cpp
+++ b/LASSIE/src/windows/MarkovModelLibraryWindow.cpp
@@ -1,8 +1,14 @@
 #include "MarkovModelLibraryWindow.hpp"
 
 #include <QAction>
+#include <QApplication>
+#include <QClipboard>
 #include <QCloseEvent>
 #include <QDoubleValidator>
+#include <QItemSelectionModel>
+#include <QKeySequence>
+#include <QModelIndexList>
+#include <QShortcut>
 #include <QGroupBox>
 #include <QHBoxLayout>
 #include <QHeaderView>
@@ -13,6 +19,7 @@
 #include <QLocale>
 #include <QMenu>
 #include <QPushButton>
+#include <QRegularExpression>
 #include <QSplitter>
 #include <QStandardItem>
 #include <QStandardItemModel>
@@ -151,7 +158,7 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
     m_distView->setItemDelegate(delegate);
     m_distView->verticalHeader()->setVisible(false);
     m_distView->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
-    m_distView->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_distView->setSelectionMode(QAbstractItemView::ExtendedSelection);
     m_distView->setFixedHeight(rowHeightFor(m_distView) + m_distView->verticalHeader()->defaultSectionSize());
 
     auto* distGroup = new QGroupBox(tr("Initial Distribution"));
@@ -167,7 +174,7 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
     m_valueView->setItemDelegate(delegate);
     m_valueView->verticalHeader()->setVisible(false);
     m_valueView->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
-    m_valueView->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_valueView->setSelectionMode(QAbstractItemView::ExtendedSelection);
     m_valueView->setFixedHeight(rowHeightFor(m_valueView) + m_valueView->verticalHeader()->defaultSectionSize());
 
     auto* valueGroup = new QGroupBox(tr("Values for states"));
@@ -183,7 +190,7 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
     m_matrixView->setItemDelegate(delegate);
     m_matrixView->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
     m_matrixView->verticalHeader()->setSectionResizeMode(QHeaderView::Interactive);
-    m_matrixView->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_matrixView->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
     auto* matrixGroup = new QGroupBox(tr("Transition Matrix"));
     auto* matrixGroupLayout = new QVBoxLayout(matrixGroup);
@@ -221,6 +228,10 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
             this, &MarkovModelLibraryWindow::onItemChanged);
     connect(m_matrixModel, &QStandardItemModel::itemChanged,
             this, &MarkovModelLibraryWindow::onItemChanged);
+
+    installCopyPasteShortcuts(m_distView);
+    installCopyPasteShortcuts(m_valueView);
+    installCopyPasteShortcuts(m_matrixView);
 }
 
 MarkovModelLibraryWindow::~MarkovModelLibraryWindow() = default;
@@ -481,4 +492,115 @@ void MarkovModelLibraryWindow::updateContextMenuEnablement() {
     const bool hasSelection = currentSelection >= 0;
     if (m_duplicateAction) m_duplicateAction->setEnabled(hasSelection);
     if (m_deleteAction)    m_deleteAction->setEnabled(hasSelection);
+}
+
+// ---------------------------------------------------------------------------
+// Copy / paste
+// ---------------------------------------------------------------------------
+
+void MarkovModelLibraryWindow::installCopyPasteShortcuts(QTableView* view) {
+    // Scoped to the view so that typing Ctrl+C/V inside an open cell editor
+    // goes to the QLineEdit's normal clipboard handling, not here.
+    auto* copy = new QShortcut(QKeySequence::Copy, view);
+    copy->setContext(Qt::WidgetShortcut);
+    connect(copy, &QShortcut::activated, this,
+            [this, view]{ copySelection(view); });
+
+    auto* paste = new QShortcut(QKeySequence::Paste, view);
+    paste->setContext(Qt::WidgetShortcut);
+    connect(paste, &QShortcut::activated, this,
+            [this, view]{ pasteSelection(view); });
+}
+
+void MarkovModelLibraryWindow::copySelection(QTableView* view) const {
+    auto* model = qobject_cast<QStandardItemModel*>(view->model());
+    if (!model) return;
+    const QModelIndexList sel = view->selectionModel()->selectedIndexes();
+    if (sel.isEmpty()) return;
+
+    // Bounding rect of the selection.
+    int minRow = sel.first().row(), maxRow = minRow;
+    int minCol = sel.first().column(), maxCol = minCol;
+    for (const QModelIndex& idx : sel) {
+        minRow = std::min(minRow, idx.row());
+        maxRow = std::max(maxRow, idx.row());
+        minCol = std::min(minCol, idx.column());
+        maxCol = std::max(maxCol, idx.column());
+    }
+
+    // Fill a dense grid; unselected cells in the bounding rect become empty
+    // so downstream paste sees a regular shape.
+    const int rows = maxRow - minRow + 1;
+    const int cols = maxCol - minCol + 1;
+    QVector<QVector<QString>> grid(rows, QVector<QString>(cols));
+    for (const QModelIndex& idx : sel) {
+        if (auto* it = model->item(idx.row(), idx.column())) {
+            grid[idx.row() - minRow][idx.column() - minCol] = it->text();
+        }
+    }
+
+    QString out;
+    for (int i = 0; i < rows; ++i) {
+        for (int j = 0; j < cols; ++j) {
+            if (j > 0) out += QLatin1Char('\t');
+            out += grid[i][j];
+        }
+        if (i + 1 < rows) out += QLatin1Char('\n');
+    }
+    QApplication::clipboard()->setText(out);
+}
+
+void MarkovModelLibraryWindow::pasteSelection(QTableView* view) {
+    auto* model = qobject_cast<QStandardItemModel*>(view->model());
+    if (!model) return;
+    const QModelIndex anchor = view->selectionModel()->currentIndex();
+    if (!anchor.isValid()) return;
+
+    const QString text = QApplication::clipboard()->text();
+    if (text.isEmpty()) return;
+
+    // Strip a single trailing newline (common from Excel / our own copy), but
+    // leave internal blank rows alone.
+    QString body = text;
+    if (body.endsWith(QLatin1Char('\n'))) body.chop(1);
+    if (body.endsWith(QLatin1Char('\r'))) body.chop(1);
+
+    // Row split accepts \r\n, \n, \r (tolerant of platform differences).
+    const QStringList rows = body.split(QRegularExpression(QStringLiteral("\r\n|\n|\r")));
+
+    const int r0 = anchor.row();
+    const int c0 = anchor.column();
+    const int rowCount = model->rowCount();
+    const int colCount = model->columnCount();
+
+    suppressItemChanged = true;
+    bool anyChange = false;
+    for (int i = 0; i < rows.size(); ++i) {
+        const int targetRow = r0 + i;
+        if (targetRow >= rowCount) break;  // overflow: drop remaining rows
+        const QStringList cells = rows[i].split(QLatin1Char('\t'));
+        for (int j = 0; j < cells.size(); ++j) {
+            const int targetCol = c0 + j;
+            if (targetCol >= colCount) break;  // overflow: drop remaining cols
+            const QString raw = cells[j].trimmed();
+            if (raw.isEmpty()) continue;  // leave empty cells alone
+            bool ok = false;
+            const double v = QLocale::c().toDouble(raw, &ok);
+            if (!ok || v < 0.0) continue;  // same validation as the delegate
+            auto* it = model->item(targetRow, targetCol);
+            if (!it) {
+                it = new QStandardItem(raw);
+                model->setItem(targetRow, targetCol, it);
+            } else {
+                it->setText(raw);
+            }
+            anyChange = true;
+        }
+    }
+    suppressItemChanged = false;
+
+    // Single save for the whole paste, not one per cell.
+    if (anyChange && currentSelection >= 0) {
+        saveEditorIntoModel(currentSelection);
+    }
 }

--- a/LASSIE/src/windows/MarkovModelLibraryWindow.cpp
+++ b/LASSIE/src/windows/MarkovModelLibraryWindow.cpp
@@ -23,6 +23,8 @@
 #include <QSplitter>
 #include <QStandardItem>
 #include <QStandardItemModel>
+#include <QUndoCommand>
+#include <QUndoStack>
 #include <QStringList>
 #include <QStyledItemDelegate>
 #include <QTableView>
@@ -30,9 +32,9 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
-#include <limits>
-
 #include <algorithm>
+#include <functional>
+#include <limits>
 
 #include "Markov.h"
 #include "../utilities.hpp"
@@ -43,11 +45,16 @@ namespace {
 // Item delegate restricting input to nonnegative real numbers (ints/doubles).
 class NonNegativeRealDelegate : public QStyledItemDelegate {
 public:
-    using QStyledItemDelegate::QStyledItemDelegate;
+    using OnEditStart = std::function<void()>;
+
+    explicit NonNegativeRealDelegate(OnEditStart onEditStart,
+                                     QObject* parent = nullptr)
+        : QStyledItemDelegate(parent), m_onEditStart(std::move(onEditStart)) {}
 
     QWidget* createEditor(QWidget* parent,
                           const QStyleOptionViewItem& /*option*/,
                           const QModelIndex& /*index*/) const override {
+        if (m_onEditStart) m_onEditStart();
         auto* editor = new QLineEdit(parent);
         auto* validator = new QDoubleValidator(
             0.0, std::numeric_limits<double>::max(), 12, editor);
@@ -90,6 +97,31 @@ public:
         }
         model->setData(index, text, Qt::EditRole);
     }
+
+private:
+    OnEditStart m_onEditStart;
+};
+
+// Undo command that captures two editor snapshots and swaps them.
+// applySnapshot is idempotent, so the initial redo() after push is harmless.
+class SnapshotCommand : public QUndoCommand {
+public:
+    SnapshotCommand(MarkovModelLibraryWindow* win,
+                    MarkovModelLibraryWindow::EditorSnapshot before,
+                    MarkovModelLibraryWindow::EditorSnapshot after,
+                    const QString& text)
+        : QUndoCommand(text),
+          m_win(win),
+          m_before(std::move(before)),
+          m_after(std::move(after)) {}
+
+    void undo() override { m_win->applySnapshot(m_before); }
+    void redo() override { m_win->applySnapshot(m_after); }
+
+private:
+    MarkovModelLibraryWindow* m_win;
+    MarkovModelLibraryWindow::EditorSnapshot m_before;
+    MarkovModelLibraryWindow::EditorSnapshot m_after;
 };
 
 QStringList numberedHeaders(int n) {
@@ -149,7 +181,12 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
     sizeRow->addStretch(1);
     rightLayout->addLayout(sizeRow);
 
-    auto* delegate = new NonNegativeRealDelegate(this);
+    m_undoStack = new QUndoStack(this);
+
+    auto* delegate = new NonNegativeRealDelegate(
+        [this]{ beginEditCapture(); }, this);
+    connect(delegate, &QAbstractItemDelegate::closeEditor, this,
+            &MarkovModelLibraryWindow::onEditorClosed);
 
     // Initial distribution
     m_distModel = new QStandardItemModel(this);
@@ -242,6 +279,7 @@ void MarkovModelLibraryWindow::setActiveProject(ProjectView* project) {
     currentSize = 0;
     m_sizeEntry->clear();
     resizeTables(0);
+    m_undoStack->clear();
     rebuildModelList();
     updateContextMenuEnablement();
 }
@@ -368,6 +406,8 @@ void MarkovModelLibraryWindow::onSelectionChanged(const QModelIndex& current,
     if (previous.isValid()) {
         saveEditorIntoModel(previous.row());
     }
+    // Undo history is specific to one model's editor session. Discard it.
+    m_undoStack->clear();
     if (current.isValid()) {
         currentSelection = current.row();
         loadModelIntoEditor(currentSelection);
@@ -389,6 +429,8 @@ void MarkovModelLibraryWindow::onSetSize() {
     const int newSize = m_sizeEntry->text().toInt(&ok);
     if (!ok || newSize <= 0) return;
     if (newSize == currentSize) return;
+
+    const EditorSnapshot before = snapshotEditor();
 
     const int oldSize = currentSize;
     QVector<QString> oldVals(oldSize);
@@ -422,6 +464,8 @@ void MarkovModelLibraryWindow::onSetSize() {
     if (currentSelection >= 0) {
         saveEditorIntoModel(currentSelection);
     }
+
+    pushSnapshotCommand(before, snapshotEditor(), tr("Change size"));
 }
 
 void MarkovModelLibraryWindow::onItemChanged(QStandardItem* /*item*/) {
@@ -499,8 +543,10 @@ void MarkovModelLibraryWindow::updateContextMenuEnablement() {
 // ---------------------------------------------------------------------------
 
 void MarkovModelLibraryWindow::installCopyPasteShortcuts(QTableView* view) {
-    // Scoped to the view so that typing Ctrl+C/V inside an open cell editor
-    // goes to the QLineEdit's normal clipboard handling, not here.
+    // Scoped to the view so that typing Ctrl+C/V/Z inside an open cell editor
+    // goes to the QLineEdit's normal handling, not here. (I.e. while a cell
+    // is being edited, Ctrl+Z does character-level undo within that QLineEdit;
+    // once the editor is dismissed, Ctrl+Z undoes the whole edit.)
     auto* copy = new QShortcut(QKeySequence::Copy, view);
     copy->setContext(Qt::WidgetShortcut);
     connect(copy, &QShortcut::activated, this,
@@ -510,6 +556,16 @@ void MarkovModelLibraryWindow::installCopyPasteShortcuts(QTableView* view) {
     paste->setContext(Qt::WidgetShortcut);
     connect(paste, &QShortcut::activated, this,
             [this, view]{ pasteSelection(view); });
+
+    auto* undo = new QShortcut(QKeySequence::Undo, view);
+    undo->setContext(Qt::WidgetShortcut);
+    connect(undo, &QShortcut::activated,
+            m_undoStack, &QUndoStack::undo);
+
+    auto* redo = new QShortcut(QKeySequence::Redo, view);
+    redo->setContext(Qt::WidgetShortcut);
+    connect(redo, &QShortcut::activated,
+            m_undoStack, &QUndoStack::redo);
 }
 
 void MarkovModelLibraryWindow::copySelection(QTableView* view) const {
@@ -573,6 +629,8 @@ void MarkovModelLibraryWindow::pasteSelection(QTableView* view) {
     const int rowCount = model->rowCount();
     const int colCount = model->columnCount();
 
+    const EditorSnapshot before = snapshotEditor();
+
     suppressItemChanged = true;
     bool anyChange = false;
     for (int i = 0; i < rows.size(); ++i) {
@@ -600,7 +658,90 @@ void MarkovModelLibraryWindow::pasteSelection(QTableView* view) {
     suppressItemChanged = false;
 
     // Single save for the whole paste, not one per cell.
-    if (anyChange && currentSelection >= 0) {
+    if (anyChange) {
+        if (currentSelection >= 0) saveEditorIntoModel(currentSelection);
+        pushSnapshotCommand(before, snapshotEditor(), tr("Paste"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Undo / redo
+// ---------------------------------------------------------------------------
+
+MarkovModelLibraryWindow::EditorSnapshot
+MarkovModelLibraryWindow::snapshotEditor() const {
+    EditorSnapshot s;
+    s.size = currentSize;
+    s.dist.resize(currentSize);
+    s.values.resize(currentSize);
+    s.matrix.resize(currentSize * currentSize);
+    for (int j = 0; j < currentSize; ++j) {
+        if (auto* it = m_distModel->item(0, j))  s.dist[j] = it->text();
+        if (auto* it = m_valueModel->item(0, j)) s.values[j] = it->text();
+    }
+    for (int i = 0; i < currentSize; ++i) {
+        for (int j = 0; j < currentSize; ++j) {
+            if (auto* it = m_matrixModel->item(i, j))
+                s.matrix[i * currentSize + j] = it->text();
+        }
+    }
+    return s;
+}
+
+void MarkovModelLibraryWindow::applySnapshot(const EditorSnapshot& s) {
+    applyingSnapshot = true;
+    suppressItemChanged = true;
+
+    if (s.size != currentSize) {
+        resizeTables(s.size);
+        m_sizeEntry->setText(QString::number(s.size));
+    }
+
+    for (int j = 0; j < s.size; ++j) {
+        m_distModel->setItem(0, j, new QStandardItem(s.dist.value(j)));
+        m_valueModel->setItem(0, j, new QStandardItem(s.values.value(j)));
+    }
+    for (int i = 0; i < s.size; ++i) {
+        for (int j = 0; j < s.size; ++j) {
+            m_matrixModel->setItem(i, j,
+                new QStandardItem(s.matrix.value(i * s.size + j)));
+        }
+    }
+
+    suppressItemChanged = false;
+    applyingSnapshot = false;
+
+    // Propagate the restored state into the backing MarkovModel so a save
+    // right after an undo persists the undone state.
+    if (currentSelection >= 0 && currentSize > 0) {
         saveEditorIntoModel(currentSelection);
     }
+}
+
+void MarkovModelLibraryWindow::beginEditCapture() {
+    if (m_editInProgress) return;  // nested / already captured
+    m_editStartSnapshot = snapshotEditor();
+    m_editInProgress = true;
+}
+
+void MarkovModelLibraryWindow::onEditorClosed() {
+    if (!m_editInProgress) return;
+    m_editInProgress = false;
+    const EditorSnapshot after = snapshotEditor();
+    pushSnapshotCommand(m_editStartSnapshot, after, tr("Edit cell"));
+}
+
+void MarkovModelLibraryWindow::pushSnapshotCommand(const EditorSnapshot& before,
+                                                   const EditorSnapshot& after,
+                                                   const QString& label) {
+    // No-op if nothing actually changed.
+    if (before.size == after.size &&
+        before.dist == after.dist &&
+        before.values == after.values &&
+        before.matrix == after.matrix) {
+        return;
+    }
+    // push() calls redo() once; state is already `after`, and applySnapshot
+    // is idempotent, so the extra call is cheap and correct.
+    m_undoStack->push(new SnapshotCommand(this, before, after, label));
 }

--- a/LASSIE/src/windows/MarkovModelLibraryWindow.cpp
+++ b/LASSIE/src/windows/MarkovModelLibraryWindow.cpp
@@ -2,6 +2,7 @@
 
 #include <QAction>
 #include <QApplication>
+#include <QCoreApplication>
 #include <QClipboard>
 #include <QCloseEvent>
 #include <QDoubleValidator>
@@ -18,7 +19,9 @@
 #include <QLineEdit>
 #include <QLocale>
 #include <QMenu>
+#include <QMessageBox>
 #include <QPushButton>
+#include <QToolButton>
 #include <QRegularExpression>
 #include <QSplitter>
 #include <QStackedWidget>
@@ -108,21 +111,83 @@ private:
 class SnapshotCommand : public QUndoCommand {
 public:
     SnapshotCommand(MarkovModelLibraryWindow* win,
+                    int modelIdx,
                     MarkovModelLibraryWindow::EditorSnapshot before,
                     MarkovModelLibraryWindow::EditorSnapshot after,
                     const QString& text)
         : QUndoCommand(text),
           m_win(win),
+          m_modelIdx(modelIdx),
           m_before(std::move(before)),
           m_after(std::move(after)) {}
 
-    void undo() override { m_win->applySnapshot(m_before); }
-    void redo() override { m_win->applySnapshot(m_after); }
+    void undo() override {
+        m_win->applySnapshotToWithDiff(m_modelIdx, m_after, m_before);
+    }
+    void redo() override {
+        m_win->applySnapshotToWithDiff(m_modelIdx, m_before, m_after);
+    }
 
 private:
     MarkovModelLibraryWindow* m_win;
+    int m_modelIdx;
     MarkovModelLibraryWindow::EditorSnapshot m_before;
     MarkovModelLibraryWindow::EditorSnapshot m_after;
+};
+
+// Create: first redo() appends a default model; subsequent redoes restore
+// whatever serialized content the model had when the user last undid it.
+class CreateModelCommand : public QUndoCommand {
+public:
+    // If initialSerialized is empty, the first redo() inserts a default model
+    // (plain "Create New"); otherwise the first redo() inserts that content
+    // (used for "Duplicate"). Subsequent redoes reuse whatever serialized
+    // state the model had when the user last undid the creation.
+    CreateModelCommand(MarkovModelLibraryWindow* win, int idx,
+                       QString label,
+                       QString initialSerialized = {})
+        : QUndoCommand(std::move(label)),
+          m_win(win),
+          m_idx(idx),
+          m_serialized(std::move(initialSerialized)),
+          m_hasSerialized(!m_serialized.isEmpty()) {}
+
+    void redo() override {
+        if (m_hasSerialized) m_win->insertModelAt(m_idx, m_serialized);
+        else                 m_win->insertDefaultModelAt(m_idx);
+    }
+    void undo() override {
+        m_serialized = m_win->serializeModelAt(m_idx);
+        m_hasSerialized = true;
+        m_win->removeModelAt(m_idx);
+    }
+
+private:
+    MarkovModelLibraryWindow* m_win;
+    int m_idx;
+    QString m_serialized;
+    bool m_hasSerialized = false;
+};
+
+// Delete: push() runs redo() which performs the removal, so the caller must
+// have captured the serialized content *before* pushing.
+class DeleteModelCommand : public QUndoCommand {
+public:
+    DeleteModelCommand(MarkovModelLibraryWindow* win, int idx, QString serialized)
+        : QUndoCommand(
+              QCoreApplication::translate("MarkovModelLibraryWindow",
+                                          "Delete Markov model %1").arg(idx)),
+          m_win(win),
+          m_idx(idx),
+          m_serialized(std::move(serialized)) {}
+
+    void redo() override { m_win->removeModelAt(m_idx); }
+    void undo() override { m_win->insertModelAt(m_idx, m_serialized); }
+
+private:
+    MarkovModelLibraryWindow* m_win;
+    int m_idx;
+    QString m_serialized;
 };
 
 QStringList numberedHeaders(int n) {
@@ -161,7 +226,44 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
     m_treeView->setSelectionMode(QAbstractItemView::SingleSelection);
     m_treeView->setContextMenuPolicy(Qt::CustomContextMenu);
     m_treeView->header()->setStretchLastSection(true);
-    splitter->addWidget(m_treeView);
+
+    // Left panel: tree view + add/remove bar.
+    auto* leftPanel = new QWidget;
+    auto* leftLayout = new QVBoxLayout(leftPanel);
+    leftLayout->setContentsMargins(0, 0, 0, 0);
+    leftLayout->setSpacing(0);
+    leftLayout->addWidget(m_treeView, /*stretch=*/1);
+
+    auto* buttonBar = new QWidget;
+    auto* buttonBarLayout = new QHBoxLayout(buttonBar);
+    buttonBarLayout->setContentsMargins(2, 2, 2, 2);
+    buttonBarLayout->setSpacing(2);
+
+    auto* addButton = new QToolButton;
+    addButton->setText(QStringLiteral("+"));
+    addButton->setToolTip(tr("Create new Markov model"));
+    addButton->setAutoRaise(true);
+
+    auto* removeButton = new QToolButton;
+    removeButton->setText(QStringLiteral("\u2212"));  // U+2212 MINUS SIGN
+    removeButton->setToolTip(tr("Delete selected Markov model"));
+    removeButton->setAutoRaise(true);
+
+    buttonBarLayout->addWidget(addButton);
+    buttonBarLayout->addWidget(removeButton);
+    buttonBarLayout->addStretch(1);
+    leftLayout->addWidget(buttonBar);
+
+    connect(addButton, &QToolButton::clicked,
+            this, &MarkovModelLibraryWindow::createNewModel);
+    connect(removeButton, &QToolButton::clicked,
+            this, &MarkovModelLibraryWindow::removeModel);
+
+    // Keep the remove button disabled when nothing is selected. Piggyback on
+    // the existing enablement path used by the context menu's Delete action.
+    m_removeButton = removeButton;
+
+    splitter->addWidget(leftPanel);
 
     // --- Right panel: stacked (empty placeholder + editor) -----------------
     m_rightStack = new QStackedWidget;
@@ -293,6 +395,21 @@ MarkovModelLibraryWindow::MarkovModelLibraryWindow(QWidget* parent)
     installCopyPasteShortcuts(m_distView);
     installCopyPasteShortcuts(m_valueView);
     installCopyPasteShortcuts(m_matrixView);
+
+    // Window-scoped undo/redo: works from anywhere in the window (tree view,
+    // size entry, plus/minus buttons, etc.) — not just when a table view has
+    // focus. While a cell editor (QLineEdit) is focused, attemptUndo/Redo
+    // defers to the QLineEdit's native character-level undo so in-progress
+    // typing can be undone character-by-character.
+    auto* winUndo = new QShortcut(QKeySequence::Undo, this);
+    winUndo->setContext(Qt::WindowShortcut);
+    connect(winUndo, &QShortcut::activated,
+            this, &MarkovModelLibraryWindow::attemptUndo);
+
+    auto* winRedo = new QShortcut(QKeySequence::Redo, this);
+    winRedo->setContext(Qt::WindowShortcut);
+    connect(winRedo, &QShortcut::activated,
+            this, &MarkovModelLibraryWindow::attemptRedo);
 }
 
 MarkovModelLibraryWindow::~MarkovModelLibraryWindow() = default;
@@ -433,8 +550,10 @@ void MarkovModelLibraryWindow::onSelectionChanged() {
         saveEditorIntoModel(previousRow);
     }
 
-    // Undo history is specific to one model's editor session. Discard it.
-    m_undoStack->clear();
+    // NOTE: we intentionally do NOT clear the undo stack here. Editor-level
+    // SnapshotCommands remember which model they apply to (and switch the
+    // tree-view selection on undo/redo), and list-level Create/Delete
+    // commands need to persist across selection changes.
 
     const QModelIndexList selected =
         m_treeView->selectionModel()->selectedRows();
@@ -516,12 +635,10 @@ void MarkovModelLibraryWindow::createNewModel() {
         saveEditorIntoModel(currentSelection);
     }
 
-    pm->markovmodels().append(MarkovModel<float>());
-    MUtilities::modified();
-
-    rebuildModelList();
-    const QModelIndex idx = m_listModel->index(pm->markovmodels().size() - 1, 0);
-    m_treeView->setCurrentIndex(idx);
+    // Push as an undoable command; redo() performs the actual append.
+    const int newIdx = pm->markovmodels().size();
+    m_undoStack->push(new CreateModelCommand(
+        this, newIdx, tr("Create Markov model %1").arg(newIdx)));
 }
 
 void MarkovModelLibraryWindow::duplicateModel() {
@@ -531,13 +648,14 @@ void MarkovModelLibraryWindow::duplicateModel() {
 
     saveEditorIntoModel(currentSelection);
 
-    if (currentSelection < pm->markovmodels().size())
-        pm->markovmodels().append(pm->markovmodels()[currentSelection]);
-    MUtilities::modified();
-
-    rebuildModelList();
-    const QModelIndex idx = m_listModel->index(pm->markovmodels().size() - 1, 0);
-    m_treeView->setCurrentIndex(idx);
+    // Duplicate = create a new model at the end, seeded with the current
+    // model's serialized contents. CreateModelCommand handles this directly.
+    const int newIdx = pm->markovmodels().size();
+    const QString serialized = serializeModelAt(currentSelection);
+    m_undoStack->push(new CreateModelCommand(
+        this, newIdx,
+        tr("Duplicate Markov model %1").arg(currentSelection),
+        serialized));
 }
 
 void MarkovModelLibraryWindow::removeModel() {
@@ -545,31 +663,22 @@ void MarkovModelLibraryWindow::removeModel() {
     ProjectManager* pm = Inst::get_project_manager();
     if (!pm || !pm->get_curr_project()) return;
 
-    if (currentSelection < pm->markovmodels().size())
-        pm->markovmodels().erase(pm->markovmodels().begin() + currentSelection);
-    MUtilities::modified();
+    // Flush editor state into the MarkovModel so the snapshot captures the
+    // most recent edits.
+    saveEditorIntoModel(currentSelection);
 
-    const int removed = currentSelection;
-    currentSelection = -1;
-    rebuildModelList();
+    const int idx = currentSelection;
+    if (idx >= pm->markovmodels().size()) return;
 
-    const int remaining = m_listModel->rowCount();
-    if (remaining > 0) {
-        const int nextRow = std::min(removed, remaining - 1);
-        m_treeView->setCurrentIndex(m_listModel->index(nextRow, 0));
-    } else {
-        resizeTables(0);
-        m_sizeEntry->clear();
-        m_rightStack->setCurrentIndex(m_emptyPageIndex);
-        m_undoStack->clear();
-        updateContextMenuEnablement();
-    }
+    const QString serialized = serializeModelAt(idx);
+    m_undoStack->push(new DeleteModelCommand(this, idx, serialized));
 }
 
 void MarkovModelLibraryWindow::updateContextMenuEnablement() {
     const bool hasSelection = currentSelection >= 0;
     if (m_duplicateAction) m_duplicateAction->setEnabled(hasSelection);
     if (m_deleteAction)    m_deleteAction->setEnabled(hasSelection);
+    if (m_removeButton)    m_removeButton->setEnabled(hasSelection);
 }
 
 // ---------------------------------------------------------------------------
@@ -594,12 +703,12 @@ void MarkovModelLibraryWindow::installCopyPasteShortcuts(QTableView* view) {
     auto* undo = new QShortcut(QKeySequence::Undo, view);
     undo->setContext(Qt::WidgetShortcut);
     connect(undo, &QShortcut::activated,
-            m_undoStack, &QUndoStack::undo);
+            this, &MarkovModelLibraryWindow::attemptUndo);
 
     auto* redo = new QShortcut(QKeySequence::Redo, view);
     redo->setContext(Qt::WidgetShortcut);
     connect(redo, &QShortcut::activated,
-            m_undoStack, &QUndoStack::redo);
+            this, &MarkovModelLibraryWindow::attemptRedo);
 }
 
 void MarkovModelLibraryWindow::copySelection(QTableView* view) const {
@@ -775,7 +884,284 @@ void MarkovModelLibraryWindow::pushSnapshotCommand(const EditorSnapshot& before,
         before.matrix == after.matrix) {
         return;
     }
+    if (currentSelection < 0) return;  // nothing to attach the command to
     // push() calls redo() once; state is already `after`, and applySnapshot
     // is idempotent, so the extra call is cheap and correct.
-    m_undoStack->push(new SnapshotCommand(this, before, after, label));
+    m_undoStack->push(new SnapshotCommand(
+        this, currentSelection, before, after, label));
+}
+
+void MarkovModelLibraryWindow::applySnapshotTo(int modelIdx,
+                                               const EditorSnapshot& s) {
+    // Ensure the target model is the one currently loaded in the editor,
+    // so applySnapshot's save path writes into the right MarkovModel.
+    if (modelIdx != currentSelection) {
+        if (modelIdx < 0 || modelIdx >= m_listModel->rowCount()) return;
+        selectTreeRow(modelIdx);
+        // selectionChanged fired synchronously → currentSelection == modelIdx,
+        // and the model was loaded into the editor.
+    } else {
+        // Already the active model, but still scroll it into view so the user
+        // sees which row the undo/redo is affecting.
+        if (modelIdx >= 0 && modelIdx < m_listModel->rowCount())
+            m_treeView->scrollTo(m_listModel->index(modelIdx, 0));
+    }
+    applySnapshot(s);
+}
+
+void MarkovModelLibraryWindow::applySnapshotToWithDiff(
+        int modelIdx,
+        const EditorSnapshot& from,
+        const EditorSnapshot& to) {
+    applySnapshotTo(modelIdx, to);
+
+    // Clear any prior selection before highlighting the changed cells.
+    if (m_distView->selectionModel())
+        m_distView->selectionModel()->clearSelection();
+    if (m_valueView->selectionModel())
+        m_valueView->selectionModel()->clearSelection();
+    if (m_matrixView->selectionModel())
+        m_matrixView->selectionModel()->clearSelection();
+
+    // If the size itself changed, the notion of "which cells differ" is
+    // ill-defined — skip highlighting rather than selecting everything.
+    if (from.size != to.size) return;
+
+    const int sz = to.size;
+    if (sz <= 0) return;
+
+    auto selectCell = [](QTableView* view, QStandardItemModel* model,
+                         int row, int col) {
+        if (!view || !model) return;
+        auto* sm = view->selectionModel();
+        if (!sm) return;
+        sm->select(model->index(row, col),
+                   QItemSelectionModel::Select);
+    };
+
+    QTableView* firstChangedView = nullptr;
+    QModelIndex firstChangedIndex;
+
+    // 1xN initial-distribution row.
+    if (from.dist.size() == sz && to.dist.size() == sz) {
+        for (int i = 0; i < sz; ++i) {
+            if (from.dist[i] != to.dist[i]) {
+                selectCell(m_distView, m_distModel, 0, i);
+                if (!firstChangedView) {
+                    firstChangedView = m_distView;
+                    firstChangedIndex = m_distModel->index(0, i);
+                }
+            }
+        }
+    }
+
+    // 1xN state-values row.
+    if (from.values.size() == sz && to.values.size() == sz) {
+        for (int i = 0; i < sz; ++i) {
+            if (from.values[i] != to.values[i]) {
+                selectCell(m_valueView, m_valueModel, 0, i);
+                if (!firstChangedView) {
+                    firstChangedView = m_valueView;
+                    firstChangedIndex = m_valueModel->index(0, i);
+                }
+            }
+        }
+    }
+
+    // NxN transition matrix.
+    if (from.matrix.size() == sz * sz && to.matrix.size() == sz * sz) {
+        for (int r = 0; r < sz; ++r) {
+            for (int c = 0; c < sz; ++c) {
+                const int k = r * sz + c;
+                if (from.matrix[k] != to.matrix[k]) {
+                    selectCell(m_matrixView, m_matrixModel, r, c);
+                    if (!firstChangedView) {
+                        firstChangedView = m_matrixView;
+                        firstChangedIndex = m_matrixModel->index(r, c);
+                    }
+                }
+            }
+        }
+    }
+
+    // Make one of the changed cells the current index and scroll it into
+    // view so the user sees the highlight.
+    if (firstChangedView && firstChangedIndex.isValid()) {
+        firstChangedView->selectionModel()->setCurrentIndex(
+            firstChangedIndex, QItemSelectionModel::NoUpdate);
+        firstChangedView->scrollTo(firstChangedIndex);
+    }
+}
+
+void MarkovModelLibraryWindow::selectTreeRow(int row) {
+    if (!m_listModel || !m_treeView) return;
+    if (row < 0 || row >= m_listModel->rowCount()) return;
+    const QModelIndex idx = m_listModel->index(row, 0);
+    m_treeView->selectionModel()->setCurrentIndex(
+        idx,
+        QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+    m_treeView->scrollTo(idx);
+}
+
+// ---------------------------------------------------------------------------
+// List-level helpers used by CreateModelCommand / DeleteModelCommand.
+// ---------------------------------------------------------------------------
+
+void MarkovModelLibraryWindow::insertDefaultModelAt(int idx) {
+    ProjectManager* pm = Inst::get_project_manager();
+    if (!pm || !pm->get_curr_project()) return;
+    auto& v = pm->markovmodels();
+    idx = std::clamp(idx, 0, static_cast<int>(v.size()));
+    v.insert(v.begin() + idx, MarkovModel<float>());
+    MUtilities::modified();
+
+    rebuildModelList();
+    // Select the newly-inserted row.
+    selectTreeRow(idx);
+}
+
+void MarkovModelLibraryWindow::insertModelAt(int idx, const QString& serialized) {
+    ProjectManager* pm = Inst::get_project_manager();
+    if (!pm || !pm->get_curr_project()) return;
+    auto& v = pm->markovmodels();
+    idx = std::clamp(idx, 0, static_cast<int>(v.size()));
+    MarkovModel<float> m;
+    if (!serialized.isEmpty()) m.from_str(serialized.toStdString());
+    v.insert(v.begin() + idx, std::move(m));
+    MUtilities::modified();
+
+    rebuildModelList();
+    selectTreeRow(idx);
+}
+
+void MarkovModelLibraryWindow::removeModelAt(int idx) {
+    ProjectManager* pm = Inst::get_project_manager();
+    if (!pm || !pm->get_curr_project()) return;
+    auto& v = pm->markovmodels();
+    if (idx < 0 || idx >= static_cast<int>(v.size())) return;
+
+    // If we're deleting the currently-loaded model, clear the selection state
+    // first so the cascading onSelectionChanged doesn't try to save editor
+    // contents into a model that's about to disappear.
+    if (currentSelection == idx) currentSelection = -1;
+    else if (currentSelection > idx) currentSelection -= 1;
+
+    v.erase(v.begin() + idx);
+    MUtilities::modified();
+
+    rebuildModelList();
+
+    const int remaining = m_listModel->rowCount();
+    if (remaining > 0) {
+        const int nextRow = std::min(idx, remaining - 1);
+        m_treeView->selectionModel()->setCurrentIndex(
+            m_listModel->index(nextRow, 0),
+            QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+    } else {
+        // selectionChanged may not fire (selection already empty) — force
+        // the empty-page transition explicitly.
+        m_treeView->selectionModel()->clearSelection();
+        currentSelection = -1;
+        resizeTables(0);
+        m_sizeEntry->clear();
+        m_rightStack->setCurrentIndex(m_emptyPageIndex);
+        updateContextMenuEnablement();
+    }
+}
+
+QString MarkovModelLibraryWindow::serializeModelAt(int idx) const {
+    ProjectManager* pm = Inst::get_project_manager();
+    if (!pm || !pm->get_curr_project()) return {};
+    auto& v = pm->markovmodels();
+    if (idx < 0 || idx >= static_cast<int>(v.size())) return {};
+
+    // MarkovModel's getters aren't const-qualified, so take a non-const ref.
+    auto& m = v[idx];
+    const int sz = m.getStateSize();
+    QString s = QString::number(sz) + "\n";
+    for (int j = 0; j < sz; ++j)
+        s += QString::number(m.getStateValue(j)) + " ";
+    s += "\n";
+    for (int j = 0; j < sz; ++j)
+        s += QString::number(m.getInitialProbability(j)) + " ";
+    s += "\n";
+    for (int i = 0; i < sz; ++i)
+        for (int j = 0; j < sz; ++j)
+            s += QString::number(m.getTransitionProbability(i, j)) + " ";
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt-wrapped undo/redo.
+// ---------------------------------------------------------------------------
+
+// Returns true if `w` is a descendant (in the QObject parent chain) of `root`.
+static bool isDescendantOf(QWidget* w, QWidget* root) {
+    for (QObject* o = w; o; o = o->parent()) {
+        if (o == root) return true;
+    }
+    return false;
+}
+
+bool MarkovModelLibraryWindow::focusIsInsideEditorTable() const {
+    QWidget* fw = QApplication::focusWidget();
+    if (!fw) return false;
+    return isDescendantOf(fw, m_distView)
+        || isDescendantOf(fw, m_valueView)
+        || isDescendantOf(fw, m_matrixView);
+}
+
+void MarkovModelLibraryWindow::attemptUndo() {
+    // When a QLineEdit has focus *outside* our editor tables (e.g. the size-
+    // entry field), let it handle Ctrl+Z character-by-character. Inside our
+    // table cells, we want Ctrl+Z to hit the editor-level undo stack — so we
+    // first commit whatever's in the open cell editor (by clearing its focus,
+    // which triggers the delegate's commit), then fall through to the stack.
+    if (auto* le = qobject_cast<QLineEdit*>(QApplication::focusWidget())) {
+        if (!focusIsInsideEditorTable()) {
+            if (le->isUndoAvailable()) { le->undo(); return; }
+        } else {
+            // Commit the in-progress cell edit so its pre-edit snapshot is
+            // pushed onto the stack, then undo that command.
+            le->clearFocus();
+        }
+    }
+    if (!m_undoStack->canUndo()) return;
+    const QString label = m_undoStack->undoText();
+    // Destructive: undoing a creation removes the model.
+    if (label.startsWith(QLatin1String("Create")) ||
+        label.startsWith(QLatin1String("Duplicate"))) {
+        const auto answer = QMessageBox::question(
+            this, tr("Undo"),
+            tr("Undo '%1'?").arg(label),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+        if (answer != QMessageBox::Yes) return;
+    }
+    m_undoStack->undo();
+}
+
+void MarkovModelLibraryWindow::attemptRedo() {
+    // Symmetric guard: let a focused QLineEdit *outside* our editor tables
+    // redo its own character-level typing first; inside a cell editor, commit
+    // and fall through to the stack.
+    if (auto* le = qobject_cast<QLineEdit*>(QApplication::focusWidget())) {
+        if (!focusIsInsideEditorTable()) {
+            if (le->isRedoAvailable()) { le->redo(); return; }
+        } else {
+            le->clearFocus();
+        }
+    }
+    if (!m_undoStack->canRedo()) return;
+    const QString label = m_undoStack->redoText();
+    // Destructive: redoing a deletion removes the model again.
+    if (label.startsWith(QLatin1String("Delete"))) {
+        const auto answer = QMessageBox::question(
+            this, tr("Redo"),
+            tr("Redo '%1'?").arg(label),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+        if (answer != QMessageBox::Yes) return;
+    }
+    m_undoStack->redo();
 }

--- a/LASSIE/src/windows/MarkovModelLibraryWindow.hpp
+++ b/LASSIE/src/windows/MarkovModelLibraryWindow.hpp
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QString>
+#include <QVector>
 
 class QAction;
 class QCloseEvent;
@@ -14,16 +15,29 @@ class QStandardItem;
 class QStandardItemModel;
 class QTableView;
 class QTreeView;
+class QUndoStack;
 class ProjectView;
 
 class MarkovModelLibraryWindow : public QMainWindow {
     Q_OBJECT
 
 public:
+    // Full state of the three tables; used as the undo/redo unit.
+    struct EditorSnapshot {
+        int size = 0;
+        QVector<QString> dist;    // length `size`
+        QVector<QString> values;  // length `size`
+        QVector<QString> matrix;  // row-major, length `size * size`
+    };
+
     explicit MarkovModelLibraryWindow(QWidget* parent = nullptr);
     ~MarkovModelLibraryWindow() override;
 
     void setActiveProject(ProjectView* project);
+
+    // Exposed so QUndoCommand subclasses can capture/restore editor state.
+    EditorSnapshot snapshotEditor() const;
+    void applySnapshot(const EditorSnapshot& s);
 
 protected:
     void hideEvent(QHideEvent* event) override;
@@ -37,6 +51,7 @@ private slots:
     void createNewModel();
     void duplicateModel();
     void removeModel();
+    void onEditorClosed();
 
 private:
     void rebuildModelList();
@@ -47,12 +62,17 @@ private:
     void installCopyPasteShortcuts(QTableView* view);
     void copySelection(QTableView* view) const;
     void pasteSelection(QTableView* view);
+    void beginEditCapture();
+    void pushSnapshotCommand(const EditorSnapshot& before,
+                             const EditorSnapshot& after,
+                             const QString& label);
     QString serializeEditor() const;
 
     ProjectView* activeProject = nullptr;
     int currentSelection = -1;
     int currentSize = 0;
     bool suppressItemChanged = false;
+    bool applyingSnapshot = false;
 
     QTreeView* m_treeView = nullptr;
     QStandardItemModel* m_listModel = nullptr;
@@ -72,6 +92,10 @@ private:
     QAction* m_createAction = nullptr;
     QAction* m_duplicateAction = nullptr;
     QAction* m_deleteAction = nullptr;
+
+    QUndoStack* m_undoStack = nullptr;
+    EditorSnapshot m_editStartSnapshot;
+    bool m_editInProgress = false;
 };
 
 #endif // MARKOVMODELLIBRARYWINDOW_HPP

--- a/LASSIE/src/windows/MarkovModelLibraryWindow.hpp
+++ b/LASSIE/src/windows/MarkovModelLibraryWindow.hpp
@@ -2,7 +2,6 @@
 #define MARKOVMODELLIBRARYWINDOW_HPP
 
 #include <QMainWindow>
-#include <QVector>
 #include <QString>
 
 class QAction;
@@ -11,9 +10,10 @@ class QHideEvent;
 class QLineEdit;
 class QMenu;
 class QPushButton;
+class QStandardItem;
 class QStandardItemModel;
+class QTableView;
 class QTreeView;
-class QWidget;
 class ProjectView;
 
 class MarkovModelLibraryWindow : public QMainWindow {
@@ -33,14 +33,14 @@ private slots:
     void onSelectionChanged(const QModelIndex& current, const QModelIndex& previous);
     void onRightClick(const QPoint& pos);
     void onSetSize();
-    void onEntryEdited();
+    void onItemChanged(QStandardItem* item);
     void createNewModel();
     void duplicateModel();
     void removeModel();
 
 private:
     void rebuildModelList();
-    void rebuildEditorGrid(int size);
+    void resizeTables(int size);
     void loadModelIntoEditor(int modelIdx);
     void saveEditorIntoModel(int modelIdx);
     void updateContextMenuEnablement();
@@ -49,6 +49,7 @@ private:
     ProjectView* activeProject = nullptr;
     int currentSelection = -1;
     int currentSize = 0;
+    bool suppressItemChanged = false;
 
     QTreeView* m_treeView = nullptr;
     QStandardItemModel* m_listModel = nullptr;
@@ -56,13 +57,13 @@ private:
     QLineEdit* m_sizeEntry = nullptr;
     QPushButton* m_sizeButton = nullptr;
 
-    QWidget* m_distGridHost = nullptr;
-    QWidget* m_valueGridHost = nullptr;
-    QWidget* m_matrixGridHost = nullptr;
+    QTableView* m_distView = nullptr;
+    QTableView* m_valueView = nullptr;
+    QTableView* m_matrixView = nullptr;
 
-    QVector<QLineEdit*> m_distEntries;
-    QVector<QLineEdit*> m_valueEntries;
-    QVector<QLineEdit*> m_matrixEntries;
+    QStandardItemModel* m_distModel = nullptr;
+    QStandardItemModel* m_valueModel = nullptr;
+    QStandardItemModel* m_matrixModel = nullptr;
 
     QMenu* m_contextMenu = nullptr;
     QAction* m_createAction = nullptr;

--- a/LASSIE/src/windows/MarkovModelLibraryWindow.hpp
+++ b/LASSIE/src/windows/MarkovModelLibraryWindow.hpp
@@ -11,6 +11,7 @@ class QHideEvent;
 class QLineEdit;
 class QMenu;
 class QPushButton;
+class QStackedWidget;
 class QStandardItem;
 class QStandardItemModel;
 class QTableView;
@@ -44,7 +45,7 @@ protected:
     void closeEvent(QCloseEvent* event) override;
 
 private slots:
-    void onSelectionChanged(const QModelIndex& current, const QModelIndex& previous);
+    void onSelectionChanged();
     void onRightClick(const QPoint& pos);
     void onSetSize();
     void onItemChanged(QStandardItem* item);
@@ -76,6 +77,10 @@ private:
 
     QTreeView* m_treeView = nullptr;
     QStandardItemModel* m_listModel = nullptr;
+
+    QStackedWidget* m_rightStack = nullptr;
+    int m_emptyPageIndex = 0;
+    int m_editorPageIndex = 1;
 
     QLineEdit* m_sizeEntry = nullptr;
     QPushButton* m_sizeButton = nullptr;

--- a/LASSIE/src/windows/MarkovModelLibraryWindow.hpp
+++ b/LASSIE/src/windows/MarkovModelLibraryWindow.hpp
@@ -44,6 +44,9 @@ private:
     void loadModelIntoEditor(int modelIdx);
     void saveEditorIntoModel(int modelIdx);
     void updateContextMenuEnablement();
+    void installCopyPasteShortcuts(QTableView* view);
+    void copySelection(QTableView* view) const;
+    void pasteSelection(QTableView* view);
     QString serializeEditor() const;
 
     ProjectView* activeProject = nullptr;

--- a/LASSIE/src/windows/MarkovModelLibraryWindow.hpp
+++ b/LASSIE/src/windows/MarkovModelLibraryWindow.hpp
@@ -15,6 +15,7 @@ class QStackedWidget;
 class QStandardItem;
 class QStandardItemModel;
 class QTableView;
+class QToolButton;
 class QTreeView;
 class QUndoStack;
 class ProjectView;
@@ -39,6 +40,20 @@ public:
     // Exposed so QUndoCommand subclasses can capture/restore editor state.
     EditorSnapshot snapshotEditor() const;
     void applySnapshot(const EditorSnapshot& s);
+    // Switches tree-view selection to modelIdx (if not already) and applies s.
+    void applySnapshotTo(int modelIdx, const EditorSnapshot& s);
+    // Same as applySnapshotTo(modelIdx, to), but additionally selects the
+    // cells in the editor tables whose content differs between `from` and
+    // `to` — used by undo/redo to highlight the cells that just changed.
+    void applySnapshotToWithDiff(int modelIdx,
+                                 const EditorSnapshot& from,
+                                 const EditorSnapshot& to);
+
+    // Exposed so list-level QUndoCommand subclasses can mutate the model list.
+    void insertDefaultModelAt(int idx);
+    void insertModelAt(int idx, const QString& serialized);
+    void removeModelAt(int idx);
+    QString serializeModelAt(int idx) const;
 
 protected:
     void hideEvent(QHideEvent* event) override;
@@ -64,9 +79,12 @@ private:
     void copySelection(QTableView* view) const;
     void pasteSelection(QTableView* view);
     void beginEditCapture();
+    void selectTreeRow(int row);
     void pushSnapshotCommand(const EditorSnapshot& before,
                              const EditorSnapshot& after,
                              const QString& label);
+    void attemptUndo();
+    void attemptRedo();
     QString serializeEditor() const;
 
     ProjectView* activeProject = nullptr;
@@ -77,6 +95,7 @@ private:
 
     QTreeView* m_treeView = nullptr;
     QStandardItemModel* m_listModel = nullptr;
+    QToolButton* m_removeButton = nullptr;
 
     QStackedWidget* m_rightStack = nullptr;
     int m_emptyPageIndex = 0;


### PR DESCRIPTION
previously a grid of QTextEdits, which made sizing horrible and would
probably not be nice to work with.

inputs are validated at save (which should be called even if a user is
looking at the window, i.e., before the data has been saved to the model,
traditionally speaking)