### PR TITLE
palette: disable sorting

### DIFF
--- a/LASSIE/src/widgets/PaletteViewController.cpp
+++ b/LASSIE/src/widgets/PaletteViewController.cpp
@@ -47,8 +47,7 @@ PaletteViewController::PaletteViewController(ProjectView* projectView)
     proxyModel->setDynamicSortFilter(true);
 
     treeView->setModel(proxyModel);
-    treeView->setSortingEnabled(true);
-    treeView->sortByColumn(1, Qt::AscendingOrder);
+    proxyModel->sort(1, Qt::AscendingOrder);
     treeView->header()->setSectionResizeMode(QHeaderView::Fixed);
     layout->addWidget(treeView, 1);
     treeView->setDragEnabled(true);


### PR DESCRIPTION
removes the little arrow that would reverse the ordering of the list if toggled. Still sorts the list on insert
