### PR TITLE
palette, mainwindow: default New Object type to selected palette item

### DIFF
--- a/LASSIE/src/dialogs/FileNewObject.cpp
+++ b/LASSIE/src/dialogs/FileNewObject.cpp
@@ -23,6 +23,25 @@ FileNewObject::~FileNewObject()
     delete ui;
 }
 
+void FileNewObject::setDefaultType(const QString& typeStr)
+{
+    ui->objNameEntry->clear();
+
+    if      (typeStr == "High")           ui->buttonHigh->setChecked(true);
+    else if (typeStr == "Mid")            ui->buttonMid->setChecked(true);
+    else if (typeStr == "Low")            ui->buttonLow->setChecked(true);
+    else if (typeStr == "Bottom")         ui->buttonBottom->setChecked(true);
+    else if (typeStr == "Spectrum")       ui->buttonSpectrum->setChecked(true);
+    else if (typeStr == "Note")           ui->buttonNote->setChecked(true);
+    else if (typeStr == "Envelope")       ui->buttonEnv->setChecked(true);
+    else if (typeStr == "Sieve")          ui->buttonSiv->setChecked(true);
+    else if (typeStr == "Spatialization") ui->buttonSpa->setChecked(true);
+    else if (typeStr == "Pattern")        ui->buttonPat->setChecked(true);
+    else if (typeStr == "Reverb")         ui->buttonRev->setChecked(true);
+    else if (typeStr == "Filter")         ui->buttonFil->setChecked(true);
+    else if (typeStr == "Measurement")    ui->buttonMea->setChecked(true);
+}
+
 void FileNewObject::accept()
 {
     if(

--- a/LASSIE/src/dialogs/FileNewObject.cpp
+++ b/LASSIE/src/dialogs/FileNewObject.cpp
@@ -27,6 +27,22 @@ void FileNewObject::setDefaultType(const QString& typeStr)
 {
     ui->objNameEntry->clear();
 
+    if (typeStr == "Top") {
+        // Top events cannot be created via New Object; clear any prior selection
+        QList<QRadioButton*> buttons = {
+            ui->buttonHigh, ui->buttonMid, ui->buttonLow, ui->buttonBottom,
+            ui->buttonSpectrum, ui->buttonNote, ui->buttonEnv, ui->buttonSiv,
+            ui->buttonSpa, ui->buttonPat, ui->buttonRev, ui->buttonFil, ui->buttonMea
+        };
+        for (QRadioButton* btn : buttons)
+            btn->setAutoExclusive(false);
+        for (QRadioButton* btn : buttons) {
+            btn->setChecked(false);
+            btn->setAutoExclusive(true);
+        }
+        return;
+    }
+
     if      (typeStr == "High")           ui->buttonHigh->setChecked(true);
     else if (typeStr == "Mid")            ui->buttonMid->setChecked(true);
     else if (typeStr == "Low")            ui->buttonLow->setChecked(true);

--- a/LASSIE/src/dialogs/FileNewObject.hpp
+++ b/LASSIE/src/dialogs/FileNewObject.hpp
@@ -19,8 +19,8 @@ public:
     
     Ui::FileNewObject *ui;
     
-    // Pre-select the radio button matching typeStr and clear the name field
-    // assumes that it is passed a non-empty string (if so, does nothing)
+    // Pre-select the radio button matching typeStr and clear the name field.
+    // If typeStr is "Top", clears all selections. Assumes non-empty string.
     void setDefaultType(const QString& typeStr);
 
 public slots:

--- a/LASSIE/src/dialogs/FileNewObject.hpp
+++ b/LASSIE/src/dialogs/FileNewObject.hpp
@@ -19,6 +19,10 @@ public:
     
     Ui::FileNewObject *ui;
     
+    // Pre-select the radio button matching typeStr and clear the name field
+    // assumes that it is passed a non-empty string (if so, does nothing)
+    void setDefaultType(const QString& typeStr);
+
 public slots:
     void accept() override;
 };

--- a/LASSIE/src/widgets/PaletteViewController.cpp
+++ b/LASSIE/src/widgets/PaletteViewController.cpp
@@ -222,6 +222,25 @@ void PaletteViewController::removeEvent(IEvent* event, const QString& type)
     }
 }
 
+QString PaletteViewController::selectedType() const {
+    QModelIndex proxyIndex = treeView->currentIndex();
+    if (!proxyIndex.isValid())
+        return {};
+
+    QModelIndex sourceIndex = proxyModel->mapToSource(proxyIndex);
+    QStandardItem* item = model->itemFromIndex(sourceIndex);
+    if (!item)
+        return {};
+
+    if (item->parent()) {
+        // Child item: column 0 holds the type string
+        return model->itemFromIndex(sourceIndex.sibling(sourceIndex.row(), 0))->text();
+    } else {
+        // Folder item: column 1 holds the folder name, which is the type
+        return model->itemFromIndex(sourceIndex.sibling(sourceIndex.row(), 1))->text();
+    }
+}
+
 QStandardItem* PaletteViewController::folderForType(const QString& typeStr) const {
     if (typeStr == "Top")            return folderTop;
     if (typeStr == "High")           return folderHigh;

--- a/LASSIE/src/widgets/PaletteViewController.hpp
+++ b/LASSIE/src/widgets/PaletteViewController.hpp
@@ -40,6 +40,9 @@ public:
     // Return the folder item for the given type string, or nullptr if unknown
     QStandardItem* folderForType(const QString& typeStr) const;
 
+    // Return the type string of the currently selected palette item, or empty string if none
+    QString selectedType() const;
+
     // Handle row removals from palette
     void onRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last);
 

--- a/LASSIE/src/widgets/ProjectViewController.cpp
+++ b/LASSIE/src/widgets/ProjectViewController.cpp
@@ -903,6 +903,10 @@ void ProjectView::insertObject() {
     if (!newObject)
         newObject = new FileNewObject(mainWindow);
 
+    const QString selectedType = paletteView->selectedType();
+    if (!selectedType.isEmpty())
+        newObject->setDefaultType(selectedType);
+
     if (newObject->exec() == QDialog::Accepted) {
         ProjectManager *pm = Inst::get_project_manager();
         QString nameStr = newObject->ui->objNameEntry->text();


### PR DESCRIPTION
When the New Object dialog opens, pre-select the radio button matching
the currently selected palette item. If a folder is selected, use the
folder's type; if a child event is selected, use its type. Closes #57.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
