### PR TITLE
rev: parse input at fungen creation, bug fixes

### DIFF
--- a/LASSIE/src/dialogs/FunctionGenerator.cpp
+++ b/LASSIE/src/dialogs/FunctionGenerator.cpp
@@ -757,6 +757,89 @@ void FunctionGenerator::setupUi()
         // <Entry>
         DOMElement* thisElement = functionNameElement->getNextElementSibling();
         ui->markovEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
+    } else if (functionName == "REV_Simple" || functionName == "REV_Medium" || functionName == "REV_Advanced") {
+        selectComboItem(functionName);
+        // selectComboItem → handleFunctionChanged → sets REVMethodFlag, creates 1 default SOUND channel
+
+        DOMElement* applyElement = functionNameElement->getNextElementSibling(); // <Apply>
+        std::string applyMethod = getFunctionString(applyElement);
+
+        // Block signals to prevent handleRevApplyMethodChanged from firing twice
+        // (once per radio button toggling) and creating orphaned layout widgets.
+        {
+            QSignalBlocker sb1(ui->revApplySound);
+            QSignalBlocker sb2(ui->revApplyPartial);
+            if (applyMethod == "PARTIAL") {
+                ui->revApplyPartial->setChecked(true);
+                ui->revApplySound->setChecked(false);
+            }
+        }
+
+        // Discard the default SOUND channel; we'll build fresh from the XML data.
+        clearRevChannels();
+
+        DOMElement* firstContainer = applyElement->getNextElementSibling(); // <Sizes> or <Percents>
+
+        if (functionName == "REV_Simple") {
+            // <Sizes><Size>...</Size>...</Sizes>
+            DOMElement* sizeEl = firstContainer->getFirstElementChild();
+            while (sizeEl != nullptr) {
+                REVChannel* chan = REVInsertChannel(m_revChannels.isEmpty() ? nullptr : m_revChannels.last());
+                chan->setRoomSizeText(QString::fromStdString(getFunctionString(sizeEl)));
+                sizeEl = sizeEl->getNextElementSibling();
+            }
+        } else if (functionName == "REV_Medium") {
+            // <Percents>, <Spreads>, <AllPasses>, <Delays>
+            DOMElement* spreadsEl   = firstContainer->getNextElementSibling();
+            DOMElement* allpassesEl = spreadsEl   ? spreadsEl->getNextElementSibling()   : nullptr;
+            DOMElement* delaysEl    = allpassesEl ? allpassesEl->getNextElementSibling() : nullptr;
+
+            DOMElement* pEl = firstContainer->getFirstElementChild();
+            DOMElement* sEl = spreadsEl   ? spreadsEl->getFirstElementChild()   : nullptr;
+            DOMElement* aEl = allpassesEl ? allpassesEl->getFirstElementChild() : nullptr;
+            DOMElement* dEl = delaysEl    ? delaysEl->getFirstElementChild()    : nullptr;
+
+            while (pEl != nullptr) {
+                REVChannel* chan = REVInsertChannel(m_revChannels.isEmpty() ? nullptr : m_revChannels.last());
+                chan->setReverbText(QString::fromStdString(getFunctionString(pEl)));
+                if (sEl) { chan->setHillowText(QString::fromStdString(getFunctionString(sEl)));  sEl = sEl->getNextElementSibling(); }
+                if (aEl) { chan->setAllGainText(QString::fromStdString(getFunctionString(aEl)));  aEl = aEl->getNextElementSibling(); }
+                if (dEl) { chan->setDelayText(QString::fromStdString(getFunctionString(dEl)));    dEl = dEl->getNextElementSibling(); }
+                pEl = pEl->getNextElementSibling();
+            }
+        } else { // REV_Advanced
+            // <Percents>, <CombGainLists>, <LPGainLists>, <AllPasses>, <Delays>
+            DOMElement* combEl      = firstContainer->getNextElementSibling();
+            DOMElement* lpEl        = combEl      ? combEl->getNextElementSibling()      : nullptr;
+            DOMElement* allpassesEl = lpEl        ? lpEl->getNextElementSibling()        : nullptr;
+            DOMElement* delaysEl    = allpassesEl ? allpassesEl->getNextElementSibling() : nullptr;
+
+            DOMElement* pEl = firstContainer->getFirstElementChild();
+            DOMElement* cEl = combEl      ? combEl->getFirstElementChild()      : nullptr;
+            DOMElement* lEl = lpEl        ? lpEl->getFirstElementChild()        : nullptr;
+            DOMElement* aEl = allpassesEl ? allpassesEl->getFirstElementChild() : nullptr;
+            DOMElement* dEl = delaysEl    ? delaysEl->getFirstElementChild()    : nullptr;
+
+            while (pEl != nullptr) {
+                REVChannel* chan = REVInsertChannel(m_revChannels.isEmpty() ? nullptr : m_revChannels.last());
+                chan->setReverbText(QString::fromStdString(getFunctionString(pEl)));
+                if (cEl) { chan->setCombGainText(QString::fromStdString(getFunctionString(cEl))); cEl = cEl->getNextElementSibling(); }
+                if (lEl) { chan->setLPGainText(QString::fromStdString(getFunctionString(lEl)));   lEl = lEl->getNextElementSibling(); }
+                if (aEl) { chan->setAllGainText(QString::fromStdString(getFunctionString(aEl)));  aEl = aEl->getNextElementSibling(); }
+                if (dEl) { chan->setDelayText(QString::fromStdString(getFunctionString(dEl)));    dEl = dEl->getNextElementSibling(); }
+                pEl = pEl->getNextElementSibling();
+            }
+        }
+
+        // Restore SOUND-mode presentation (title + hidden buttons) if applicable.
+        if (applyMethod != "PARTIAL" && !m_revChannels.isEmpty()) {
+            m_revChannels.first()->setTitle("Sound");
+            m_revChannels.first()->hideButtons();
+        }
+    } else if (functionName == "ReadREVFile") {
+        selectComboItem(functionName);
+        DOMElement* fileElement = functionNameElement->getNextElementSibling(); // <File>
+        ui->readRevFileEdit->setText(QString::fromStdString(getFunctionString(fileElement)));
     }
 }
 
@@ -1880,8 +1963,8 @@ void FunctionGenerator::REVTextChanged(){
         case 1: stringbuffer = "<Fun><Name>REV_Medium</Name><Apply>"; break;
         case 2: stringbuffer = "<Fun><Name>REV_Advanced</Name><Apply>"; break;
     }
-    if (ui->revApplySound->isChecked() == 0) { stringbuffer = stringbuffer +"SOUND"; }
-    else if (ui->revApplyPartial->isChecked() == 1) { stringbuffer = stringbuffer +"PARTIAL"; }
+    if (ui->revApplySound->isChecked()) { stringbuffer += "SOUND"; }
+    else { stringbuffer += "PARTIAL"; }
     stringbuffer += "</Apply>";
 
     switch (REVMethodFlag) {
@@ -1969,7 +2052,8 @@ void FunctionGenerator::updateRevChaLabels() {
 }
 void FunctionGenerator::clearRevChannels() {
     for (REVChannel* chan : m_revChannels) {
-        chan->deleteLater();
+        ui->revScrollWindowLayout->removeWidget(chan);
+        delete chan;
     }
     m_revChannels.clear();
     REVTextChanged();

--- a/LASSIE/src/widgets/REVChannel.cpp
+++ b/LASSIE/src/widgets/REVChannel.cpp
@@ -123,3 +123,11 @@ void REVChannel::hideButtons() {
     m_insBtn->hide();
     m_rmBtn->hide();
 }
+
+void REVChannel::setRoomSizeText(const QString& text) { if (room_size) room_size->setText(text); }
+void REVChannel::setReverbText(const QString& text)   { if (reverb)    reverb->setText(text); }
+void REVChannel::setHillowText(const QString& text)   { if (hillow)    hillow->setText(text); }
+void REVChannel::setAllGainText(const QString& text)  { if (all_gain)  all_gain->setText(text); }
+void REVChannel::setDelayText(const QString& text)    { if (delay)     delay->setText(text); }
+void REVChannel::setCombGainText(const QString& text) { if (comb_gain) comb_gain->setText(text); }
+void REVChannel::setLPGainText(const QString& text)   { if (lp_gain)   lp_gain->setText(text); }

--- a/LASSIE/src/widgets/REVChannel.hpp
+++ b/LASSIE/src/widgets/REVChannel.hpp
@@ -22,6 +22,14 @@ public:
     void hideButtons();
     void setTitle(const QString& text);
 
+    void setRoomSizeText(const QString& text);
+    void setReverbText(const QString& text);
+    void setHillowText(const QString& text);
+    void setAllGainText(const QString& text);
+    void setDelayText(const QString& text);
+    void setCombGainText(const QString& text);
+    void setLPGainText(const QString& text);
+
 signals:
     void textChanged();
     void insertChannelRequested(REVChannel* self);


### PR DESCRIPTION
populates the dialog with relevant data from xml string; also does ReadREVFile

fixes bug with writing the partial/sound apply string that would make neither be written when they should've been

delete initial "sound" widget immediately, not later (caused "ghost box")