### PR TITLE
fungen: implement MakeEnvelope (#66)

### DIFF
--- a/LASSIE/CMakeLists.txt
+++ b/LASSIE/CMakeLists.txt
@@ -33,6 +33,7 @@ qt_add_executable(LASSIE
     src/widgets/Modifiers.cpp src/widgets/Modifiers.hpp src/ui/Modifiers.ui
     src/widgets/Stochos.cpp src/widgets/Stochos.hpp
     src/widgets/Select.cpp src/widgets/Select.hpp
+    src/widgets/MakeEnvelopeRow.cpp src/widgets/MakeEnvelopeRow.hpp
     src/widgets/generic/FunctionEntryRow.cpp src/widgets/generic/FunctionEntryRow.hpp
 )
 

--- a/LASSIE/src/dialogs/FunctionGenerator.cpp
+++ b/LASSIE/src/dialogs/FunctionGenerator.cpp
@@ -20,6 +20,7 @@
 
 #include "../widgets/Stochos.hpp"
 #include "../widgets/Select.hpp"
+#include "../widgets/MakeEnvelopeRow.hpp"
 
 
 FunctionGenerator::FunctionGenerator(QWidget *parent, FunctionReturnType _returnType, QString _originalString)
@@ -316,11 +317,7 @@ void FunctionGenerator::setupUi()
 
     // MakeEnvelope Signals
     connect(ui->makeEnvelopeScalingInsertFn, &QPushButton::clicked, this, &FunctionGenerator::makeEnvelopeScalingFactorFunButtonClicked);
-    connect(ui->makeEnvelopeXInsertFn, &QPushButton::clicked, this, &FunctionGenerator::makeEnvelopeXValueFunButtonClicked);
-    connect(ui->makeEnvelopeYInsertFn, &QPushButton::clicked, this, &FunctionGenerator::makeEnvelopeYValueFunButtonClicked);
     connect(ui->makeEnvelopeScalingEdit, &QLineEdit::textChanged, this, &FunctionGenerator::makeEnvelopeTextChanged);
-    connect(ui->makeEnvelopeXEdit, &QLineEdit::textChanged, this, &FunctionGenerator::makeEnvelopeTextChanged);
-    connect(ui->makeEnvelopeYEdit, &QLineEdit::textChanged, this, &FunctionGenerator::makeEnvelopeTextChanged);
 
     // MakePattern Signals
     connect(ui->makePatternIntervalsInsertFn, &QPushButton::clicked, this, &FunctionGenerator::makePatternIntervalsFunButtonClicked);
@@ -951,8 +948,43 @@ void FunctionGenerator::setupUi()
         selectComboItem(functionName);
         DOMElement* thisElement = functionNameElement->getNextElementSibling();
         ui->fibEdit->setText(QString::fromStdString(getFunctionString(thisElement)));
-    } 
-    //not work: stochos, select, Decay, SPA, REV_Simple, REV_Medium, REV_Advanced, 
+    } else if (functionName == "MakeEnvelope") {
+        selectComboItem(functionName);
+        // handleFunctionChanged created 2 default rows — discard them
+        clearEnvRows();
+
+        // <Xs>, <Ys>, <Types>, <Pros>, <Scale>
+        DOMElement* xsEl    = functionNameElement->getNextElementSibling();
+        DOMElement* ysEl    = xsEl    ? xsEl->getNextElementSibling()    : nullptr;
+        DOMElement* typesEl = ysEl    ? ysEl->getNextElementSibling()    : nullptr;
+        DOMElement* prosEl  = typesEl ? typesEl->getNextElementSibling() : nullptr;
+        DOMElement* scaleEl = prosEl  ? prosEl->getNextElementSibling()  : nullptr;
+
+        DOMElement* xEl = xsEl ? xsEl->getFirstElementChild() : nullptr;
+        DOMElement* yEl = ysEl ? ysEl->getFirstElementChild() : nullptr;
+        DOMElement* tEl = typesEl ? typesEl->getFirstElementChild() : nullptr;
+        DOMElement* pEl = prosEl  ? prosEl->getFirstElementChild()  : nullptr;
+
+        while (xEl != nullptr && yEl != nullptr) {
+            MakeEnvelopeRow* row = envInsertRow(m_envRows.isEmpty() ? nullptr : m_envRows.last());
+            row->setX(QString::fromStdString(getFunctionString(xEl)));
+            row->setY(QString::fromStdString(getFunctionString(yEl)));
+            if (tEl != nullptr) {
+                row->setType(QString::fromStdString(getFunctionString(tEl)));
+                tEl = tEl->getNextElementSibling();
+            }
+            if (pEl != nullptr) {
+                row->setPro(QString::fromStdString(getFunctionString(pEl)));
+                pEl = pEl->getNextElementSibling();
+            }
+            xEl = xEl->getNextElementSibling();
+            yEl = yEl->getNextElementSibling();
+        }
+
+        if (scaleEl)
+            ui->makeEnvelopeScalingEdit->setText(QString::fromStdString(getFunctionString(scaleEl)));
+    }
+    //not work: stochos, select, Decay,
 }
 
 std::string FunctionGenerator::getFunctionString(DOMElement* _thisFunctionElement){
@@ -1123,6 +1155,13 @@ void FunctionGenerator::handleFunctionChanged(int index)
             break;
         case functionMakeEnvelope:
             currPageIndex = 17;
+            ui->makeEnvelopeScrollWindowLayout->setSpacing(5);
+            ui->makeEnvelopeScrollWindowLayout->setContentsMargins(5, 5, 5, 5);
+            if (m_envRows.isEmpty()) {
+                ui->makeEnvelopeScalingEdit->setText("1.0");
+                envInsertRow(nullptr);
+                envInsertRow(m_envRows.last());
+            }
             makeEnvelopeTextChanged();
             break;
         case functionReadENVFile:
@@ -1846,37 +1885,62 @@ void FunctionGenerator::makeEnvelopeScalingFactorFunButtonClicked(){
   }
   delete generator;
 }
-void FunctionGenerator::makeEnvelopeXValueFunButtonClicked(){
-  QString initialText = ui->makeEnvelopeXEdit->text();
-  FunctionGenerator* generator = new FunctionGenerator(this, functionReturnFloat, initialText);
-  if (generator->exec() == QDialog::Accepted) {
-    QString result = generator->getResultString();
-    if (!result.isEmpty()) {
-        ui->makeEnvelopeXEdit->setText(result);
-    }
-  }
-  delete generator;
+
+MakeEnvelopeRow* FunctionGenerator::envInsertRow(MakeEnvelopeRow* prevRow) {
+    int index = prevRow ? m_envRows.indexOf(prevRow) + 1 : 0;
+    auto* row = new MakeEnvelopeRow(index, ui->makeEnvelopeScrollWindowContents);
+    m_envRows.insert(index, row);
+    ui->makeEnvelopeScrollWindowLayout->insertWidget(index, row);
+    updateEnvRowLabels();
+    connect(row, &MakeEnvelopeRow::textChanged,    this, [this](MakeEnvelopeRow*){ makeEnvelopeTextChanged(); });
+    connect(row, &MakeEnvelopeRow::deleteRequested, this, [this](MakeEnvelopeRow* r){ envRemoveRow(r); });
+    connect(row, &MakeEnvelopeRow::insertRequested, this, [this](MakeEnvelopeRow* r){ envInsertRow(r); });
+    makeEnvelopeTextChanged();
+    return row;
 }
-void FunctionGenerator::makeEnvelopeYValueFunButtonClicked(){
-  QString initialText = ui->makeEnvelopeYEdit->text();
-  FunctionGenerator* generator = new FunctionGenerator(this, functionReturnFloat, initialText);
-  if (generator->exec() == QDialog::Accepted) {
-    QString result = generator->getResultString();
-    if (!result.isEmpty()) {
-        ui->makeEnvelopeYEdit->setText(result);
-    }
-  }
-  delete generator;
+
+void FunctionGenerator::envRemoveRow(MakeEnvelopeRow* currRow) {
+    if (m_envRows.size() <= 2) return;
+    int index = m_envRows.indexOf(currRow);
+    if (index < 0) return;
+    m_envRows.removeAt(index);
+    ui->makeEnvelopeScrollWindowLayout->removeWidget(currRow);
+    currRow->deleteLater();
+    updateEnvRowLabels();
+    makeEnvelopeTextChanged();
 }
+
+void FunctionGenerator::clearEnvRows() {
+    for (auto* row : m_envRows) {
+        ui->makeEnvelopeScrollWindowLayout->removeWidget(row);
+        delete row;
+    }
+    m_envRows.clear();
+}
+
+void FunctionGenerator::updateEnvRowLabels() {
+    for (int i = 0; i < m_envRows.size(); ++i)
+        m_envRows[i]->setLabel(QString("Point %1:").arg(i + 1));
+}
+
 void FunctionGenerator::makeEnvelopeTextChanged(){
-    QString stringbuffer;
-    stringbuffer = "<Fun><Name>MakeEnvelope</Name><Xs>";
-    // TO DO: MakeEnvelopeSubAlignment
-    stringbuffer = stringbuffer + "<X>" + ui->makeEnvelopeXEdit->text() + "</X></Xs><Ys>";
-    stringbuffer = stringbuffer + "<Y>" + ui->makeEnvelopeYEdit->text() + "</Y></Ys><Types>";
-    stringbuffer = stringbuffer + "</Types><Pros>";
-    stringbuffer = stringbuffer+ "</Pros><Scale>" + ui->makeEnvelopeScalingEdit->text() + "</Scale></Fun>";
-    ui->resultTextEdit->setText(stringbuffer);
+    if (m_envRows.isEmpty()) return;
+    QString xs, ys, types, pros;
+    for (int i = 0; i < m_envRows.size(); ++i) {
+        xs    += "<X>" + m_envRows[i]->getX() + "</X>";
+        ys    += "<Y>" + m_envRows[i]->getY() + "</Y>";
+        if (i < m_envRows.size() - 1) {
+            types += "<T>" + m_envRows[i]->getType() + "</T>";
+            pros  += "<P>" + m_envRows[i]->getPro()  + "</P>";
+        }
+    }
+    QString result = "<Fun><Name>MakeEnvelope</Name>"
+                     "<Xs>" + xs + "</Xs>"
+                     "<Ys>" + ys + "</Ys>"
+                     "<Types>" + types + "</Types>"
+                     "<Pros>" + pros + "</Pros>"
+                     "<Scale>" + ui->makeEnvelopeScalingEdit->text() + "</Scale></Fun>";
+    ui->resultTextEdit->setText(result);
 }
 
 /* MakePattern Signal Functions */

--- a/LASSIE/src/dialogs/FunctionGenerator.hpp
+++ b/LASSIE/src/dialogs/FunctionGenerator.hpp
@@ -14,6 +14,7 @@ class SPAChannel;
 class REVChannel;
 class Stochos;
 class Select;
+class MakeEnvelopeRow;
 
 namespace Ui {
 class FunctionGenerator;
@@ -131,10 +132,13 @@ public:
     void envLibScalingFactorFunButtonClicked();
     void envLibTextChanged();
 
-    // MakeEnvelopes
+    // MakeEnvelope
+    QList<MakeEnvelopeRow*> m_envRows;
+    MakeEnvelopeRow* envInsertRow(MakeEnvelopeRow* prevRow);
+    void envRemoveRow(MakeEnvelopeRow* currRow);
+    void clearEnvRows();
+    void updateEnvRowLabels();
     void makeEnvelopeScalingFactorFunButtonClicked();
-    void makeEnvelopeXValueFunButtonClicked();
-    void makeEnvelopeYValueFunButtonClicked();
     void makeEnvelopeTextChanged();
 
     // MakePattern

--- a/LASSIE/src/ui/FunctionGenerator.ui
+++ b/LASSIE/src/ui/FunctionGenerator.ui
@@ -1118,48 +1118,6 @@
         </widget>
         </item>
         <item>
-        <layout class="QHBoxLayout" name="makeEnvelopeXLayout">
-            <item>
-                <widget class="QLabel" name="makeEnvelopeXLabel">
-                <property name="text">
-                <string>X Value:</string>
-                </property>
-                </widget>
-            </item>
-            <item>
-                <widget class="QLineEdit" name="makeEnvelopeXEdit"/>
-            </item>
-            <item>
-                <widget class="QPushButton" name="makeEnvelopeXInsertFn">
-                <property name="text">
-                    <string>Insert Function</string>
-                </property>
-                </widget>
-            </item>
-        </layout>
-        </item>
-        <item>
-        <layout class="QHBoxLayout" name="makeEnvelopeYLayout">
-            <item>
-                <widget class="QLabel" name="makeEnvelopeYLabel">
-                <property name="text">
-                <string>Y Value:</string>
-                </property>
-                </widget>
-            </item>
-            <item>
-                <widget class="QLineEdit" name="makeEnvelopeYEdit"/>
-            </item>
-            <item>
-                <widget class="QPushButton" name="makeEnvelopeYInsertFn">
-                <property name="text">
-                    <string>Insert Function</string>
-                </property>
-                </widget>
-            </item>
-        </layout>
-        </item>
-        <item>
         <layout class="QHBoxLayout" name="makeEnvelopeScalingLayout">
             <item>
                 <widget class="QLabel" name="makeEnvelopeScalingLabel">

--- a/LASSIE/src/widgets/MakeEnvelopeRow.cpp
+++ b/LASSIE/src/widgets/MakeEnvelopeRow.cpp
@@ -1,0 +1,107 @@
+#include "MakeEnvelopeRow.hpp"
+#include "../dialogs/FunctionGenerator.hpp"
+
+MakeEnvelopeRow::MakeEnvelopeRow(int index, QWidget* parent)
+    : QFrame(parent), m_index(index)
+{
+    setFrameShape(QFrame::NoFrame);
+
+    m_hBox = new QHBoxLayout(this);
+    m_hBox->setContentsMargins(0, 0, 0, 0);
+    m_hBox->setSpacing(4);
+
+    m_label   = new QLabel(QString("Point %1:").arg(index + 1));
+    m_xEdit   = new QLineEdit;
+    m_xFnBtn  = new QPushButton("fn");
+    m_yEdit   = new QLineEdit;
+    m_yFnBtn  = new QPushButton("fn");
+
+    m_typeCombo = new QComboBox;
+    m_typeCombo->addItem("LINEAR");
+    m_typeCombo->addItem("SPLINE");
+    m_typeCombo->addItem("EXPONENTIAL");
+
+    m_proCombo = new QComboBox;
+    m_proCombo->addItem("FLEXIBLE");
+    m_proCombo->addItem("FIXED");
+
+    m_rmBtn  = new QPushButton("rm");
+    m_insBtn = new QPushButton("ins");
+
+    m_hBox->addWidget(m_label);
+    m_hBox->addWidget(new QLabel("X:"));
+    m_hBox->addWidget(m_xEdit);
+    m_hBox->addWidget(m_xFnBtn);
+    m_hBox->addWidget(new QLabel("Y:"));
+    m_hBox->addWidget(m_yEdit);
+    m_hBox->addWidget(m_yFnBtn);
+    m_hBox->addWidget(m_typeCombo);
+    m_hBox->addWidget(m_proCombo);
+    m_hBox->addWidget(m_rmBtn);
+    m_hBox->addWidget(m_insBtn);
+
+    m_xEdit->setFixedHeight(20);
+    m_yEdit->setFixedHeight(20);
+
+    connect(m_xFnBtn,    &QPushButton::clicked, this, &MakeEnvelopeRow::onXFnClicked);
+    connect(m_yFnBtn,    &QPushButton::clicked, this, &MakeEnvelopeRow::onYFnClicked);
+    connect(m_rmBtn,     &QPushButton::clicked, this, &MakeEnvelopeRow::onRmClicked);
+    connect(m_insBtn,    &QPushButton::clicked, this, &MakeEnvelopeRow::onInsClicked);
+    connect(m_xEdit,     &QLineEdit::textChanged,
+            this, &MakeEnvelopeRow::onChanged);
+    connect(m_yEdit,     &QLineEdit::textChanged,
+            this, &MakeEnvelopeRow::onChanged);
+    connect(m_typeCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &MakeEnvelopeRow::onChanged);
+    connect(m_proCombo,  qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &MakeEnvelopeRow::onChanged);
+
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+}
+
+MakeEnvelopeRow::~MakeEnvelopeRow() {}
+
+void MakeEnvelopeRow::setIndex(int index) {
+    m_index = index;
+    setLabel(QString("Point %1:").arg(index + 1));
+}
+
+QString MakeEnvelopeRow::getX() const { return m_xEdit->text(); }
+QString MakeEnvelopeRow::getY() const { return m_yEdit->text(); }
+QString MakeEnvelopeRow::getType() const { return m_typeCombo->currentText(); }
+QString MakeEnvelopeRow::getPro()  const { return m_proCombo->currentText(); }
+
+void MakeEnvelopeRow::setX(const QString& text) { m_xEdit->setText(text); }
+void MakeEnvelopeRow::setY(const QString& text) { m_yEdit->setText(text); }
+
+void MakeEnvelopeRow::setType(const QString& type) {
+    int i = m_typeCombo->findText(type);
+    if (i >= 0) m_typeCombo->setCurrentIndex(i);
+}
+
+void MakeEnvelopeRow::setPro(const QString& pro) {
+    int i = m_proCombo->findText(pro);
+    if (i >= 0) m_proCombo->setCurrentIndex(i);
+}
+
+void MakeEnvelopeRow::setLabel(const QString& text) {
+    if (m_label) m_label->setText(text);
+}
+
+void MakeEnvelopeRow::onXFnClicked() {
+    FunctionGenerator* gen = new FunctionGenerator(nullptr, functionReturnFloat, m_xEdit->text());
+    if (gen->exec() == QDialog::Accepted && !gen->getResultString().isEmpty())
+        m_xEdit->setText(gen->getResultString());
+    delete gen;
+}
+
+void MakeEnvelopeRow::onYFnClicked() {
+    FunctionGenerator* gen = new FunctionGenerator(nullptr, functionReturnFloat, m_yEdit->text());
+    if (gen->exec() == QDialog::Accepted && !gen->getResultString().isEmpty())
+        m_yEdit->setText(gen->getResultString());
+    delete gen;
+}
+
+void MakeEnvelopeRow::onRmClicked()  { emit deleteRequested(this); }
+void MakeEnvelopeRow::onInsClicked() { emit insertRequested(this); }
+void MakeEnvelopeRow::onChanged()    { emit textChanged(this); }

--- a/LASSIE/src/widgets/MakeEnvelopeRow.hpp
+++ b/LASSIE/src/widgets/MakeEnvelopeRow.hpp
@@ -1,0 +1,63 @@
+#ifndef MAKE_ENVELOPE_ROW_HPP
+#define MAKE_ENVELOPE_ROW_HPP
+
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QComboBox>
+#include <QString>
+
+#include "../lassie.hpp"
+
+class MakeEnvelopeRow : public QFrame {
+    Q_OBJECT
+
+public:
+    MakeEnvelopeRow(int index, QWidget* parent = nullptr);
+    ~MakeEnvelopeRow() override;
+
+    int     getIndex() const { return m_index; }
+    void    setIndex(int index);
+
+    QString getX() const;
+    QString getY() const;
+    QString getType() const;
+    QString getPro() const;
+
+    void setX(const QString& text);
+    void setY(const QString& text);
+    void setType(const QString& type);
+    void setPro(const QString& pro);
+
+    void setLabel(const QString& text);
+
+signals:
+    void deleteRequested(MakeEnvelopeRow* self);
+    void insertRequested(MakeEnvelopeRow* self);
+    void textChanged(MakeEnvelopeRow* self);
+
+private slots:
+    void onXFnClicked();
+    void onYFnClicked();
+    void onRmClicked();
+    void onInsClicked();
+    void onChanged();
+
+private:
+    int m_index;
+
+    QHBoxLayout* m_hBox      = nullptr;
+    QLabel*      m_label     = nullptr;
+    QLineEdit*   m_xEdit     = nullptr;
+    QPushButton* m_xFnBtn    = nullptr;
+    QLineEdit*   m_yEdit     = nullptr;
+    QPushButton* m_yFnBtn    = nullptr;
+    QComboBox*   m_typeCombo = nullptr;
+    QComboBox*   m_proCombo  = nullptr;
+    QPushButton* m_rmBtn     = nullptr;
+    QPushButton* m_insBtn    = nullptr;
+};
+
+#endif


### PR DESCRIPTION
## Summary

- Creates `MakeEnvelopeRow` widget: each row holds X, Y, interpolation type (LINEAR/SPLINE/EXPONENTIAL), and proportion type (FLEXIBLE/FIXED) for one envelope point, with `rm`/`ins` buttons for dynamic row management
- Replaces the single-field X/Y placeholder in the `makeEnvelopePage` with a dynamic scroll-area list of `MakeEnvelopeRow` widgets (minimum 2 rows enforced)
- `makeEnvelopeTextChanged()` now generates correct multi-point XML: `<Xs>`, `<Ys>`, `<Types>` (N-1 segments), `<Pros>` (N-1 segments), `<Scale>`
- Adds the `MakeEnvelope` case to the FunctionGenerator constructor XML parser, restoring all points and segment types from a saved XML string

## Test plan

- [ ] Open the Function Generator with return type ENV — select MakeEnvelope; two default rows appear, scaling defaults to 1.0
- [ ] Add/remove rows with `ins`/`rm` buttons; confirm rm is blocked at 2 rows
- [ ] Set X, Y, type, pro values; confirm the result XML in the text area updates
- [ ] Open an existing MakeEnvelope XML string in the generator; confirm all rows and scaling are restored correctly
- [ ] Confirm CMOD can parse the generated XML without errors

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)