### PR TITLE
[macos] lass: use Accelerate library for reverb

### DIFF
--- a/LASS/CMakeLists.txt
+++ b/LASS/CMakeLists.txt
@@ -23,6 +23,11 @@ add_library(LASS STATIC ${LASS_SRC})
 target_link_libraries(LASS PUBLIC ${SNDFILE_LIBRARY})
 message(STATUS "libsndfile linked with target!")
 
+if(APPLE)
+    target_link_libraries(LASS PUBLIC "-framework Accelerate")
+    message(STATUS "Accelerate framework linked for vDSP reverb optimisation!")
+endif()
+
 target_include_directories(LASS PUBLIC
     "${PROJECT_SOURCE_DIR}/src"
     ${SNDFILE_INCLUDE_DIR}

--- a/LASS/src/AllPassFilter.cpp
+++ b/LASS/src/AllPassFilter.cpp
@@ -38,6 +38,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "LowPassFilter.h"
 #include "AllPassFilter.h"
 
+#ifdef __APPLE__
+#include <vecLib/vDSP.h>
+#endif
+
 //----------------------------------------------------------------------------//
 
 AllPassFilter::AllPassFilter(float gain, long delay)
@@ -76,6 +80,60 @@ m_sample_type AllPassFilter::do_filter(m_sample_type x_t)
         y_hist->enqueue(y_t);
 	return y_t;
 }
+
+//----------------------------------------------------------------------------//
+
+#ifdef __APPLE__
+void AllPassFilter::do_filter_buffer(const float* in, float* out, long n)
+{
+	// y(t) = -g*x(t) + (1-g²)*(x(t-D) + g*y(t-D))
+	//
+	// Since the recurrence closes over D samples (not 1), within each
+	// D-sample block all outputs are independent — x(t-D) and y(t-D)
+	// are fully determined by the previous block.  vDSP handles the
+	// arithmetic for each block.
+	//
+	// Coefficients (precomputed from g and g_sqrd):
+	//   coef_g          = g
+	//   one_minus_gsq   = 1 - g²
+	//   neg_g           = -g
+	const float one_minus_gsq = 1.0f - g_sqrd;
+	const float neg_g         = -g;
+
+	std::vector<float> x_prev(D), y_prev(D), tmp(D);
+
+	long i = 0;
+	while (i < n) {
+		long block = std::min((long)D, n - i);
+
+		// Drain the D oldest values from each history queue.
+		for (long j = 0; j < block; j++) {
+			x_prev[j] = x_hist->dequeue();
+			y_prev[j] = y_hist->dequeue();
+		}
+
+		// tmp[j] = g * y_prev[j] + x_prev[j]
+		vDSP_vsma(y_prev.data(), 1, &g, x_prev.data(), 1, tmp.data(), 1,
+		          (vDSP_Length)block);
+
+		// tmp[j] = (1 - g²) * tmp[j]
+		vDSP_vsmul(tmp.data(), 1, &one_minus_gsq, tmp.data(), 1,
+		           (vDSP_Length)block);
+
+		// out[i+j] = (-g) * in[i+j] + tmp[j]
+		vDSP_vsma(in + i, 1, &neg_g, tmp.data(), 1, out + i, 1,
+		          (vDSP_Length)block);
+
+		// Push new input and output into the history queues.
+		for (long j = 0; j < block; j++) {
+			x_hist->enqueue(in[i + j]);
+			y_hist->enqueue(out[i + j]);
+		}
+
+		i += block;
+	}
+}
+#endif
 
 //----------------------------------------------------------------------------//
 

--- a/LASS/src/AllPassFilter.h
+++ b/LASS/src/AllPassFilter.h
@@ -70,6 +70,18 @@ public:
 	 **/
 	m_sample_type do_filter(m_sample_type x_t);
 
+#ifdef __APPLE__
+	/**
+	 * macOS-optimised block version: equivalent to calling do_filter n times.
+	 * Processes in D-sample batches; within each batch all outputs are
+	 * independent of one another, enabling vDSP SIMD acceleration.
+	 * \param in  Input sample array (length n)
+	 * \param out Output sample array (length n)
+	 * \param n   Number of samples to process
+	 **/
+	void do_filter_buffer(const float* in, float* out, long n);
+#endif
+
 	/**
 	 * This method should be redefined by each class derived from Filter
 	 * to reset the filter to an initial state.  It should have the 

--- a/LASS/src/Filter.h
+++ b/LASS/src/Filter.h
@@ -249,6 +249,12 @@ public:
 			return array[idx];
 		}
 
+		// Raw access for performance-critical buffer processing (use carefully).
+		ElemType* raw_array() { return array; }
+		long raw_length() const { return length; }
+		long& raw_back() { return back_idx; }
+		long& raw_front() { return front_idx; }
+
 	private:
 
 		/**

--- a/LASS/src/LPCombFilter.cpp
+++ b/LASS/src/LPCombFilter.cpp
@@ -74,6 +74,37 @@ m_sample_type LPCombFilter::do_filter(m_sample_type x_t)
 }
 
 //----------------------------------------------------------------------------//
+#ifdef __APPLE__
+void LPCombFilter::do_filter_buffer(const float* in, float* out, long n)
+{
+	// Access ring-buffer internals directly to eliminate per-sample call overhead.
+	float* arr  = x_hist->raw_array();
+	long   len  = x_hist->raw_length();   // == D
+	long   back = x_hist->raw_back();
+	long   front = x_hist->raw_front();
+	float  lpf_s = lpf->get_state();
+
+	for (long i = 0; i < n; i++) {
+		float delayed = arr[back];
+		if (++back >= len) back = 0;
+
+		// Inline 1st-order IIR: lpf_out = delayed + lpf_g * lpf_state
+		float lpf_out = delayed + lpf_g * lpf_s;
+		lpf_s = lpf_out;
+
+		arr[front] = in[i] + g * lpf_out;
+		if (++front >= len) front = 0;
+
+		out[i] = delayed;
+	}
+
+	x_hist->raw_back()  = back;
+	x_hist->raw_front() = front;
+	lpf->set_state(lpf_s);
+}
+#endif
+
+//----------------------------------------------------------------------------//
 void LPCombFilter::reset()
 {
 	// recreate the low-pass-feedback unit and the x-history queue

--- a/LASS/src/LPCombFilter.h
+++ b/LASS/src/LPCombFilter.h
@@ -95,6 +95,18 @@ public:
 	 **/
 	m_sample_type do_filter(m_sample_type x_t);
 
+#ifdef __APPLE__
+	/**
+	 * macOS-optimised block version: equivalent to calling do_filter n times.
+	 * Uses a tight inline loop with direct ring-buffer and LPF state access to
+	 * eliminate per-sample virtual-dispatch and function-call overhead.
+	 * \param in  Input sample array (length n)
+	 * \param out Output sample array (length n)
+	 * \param n   Number of samples to process
+	 **/
+	void do_filter_buffer(const float* in, float* out, long n);
+#endif
+
 	/**
 	 * This method should be redefined by each class derived from Filter to
 	 * reset the filter to an initial state.  It should have the same effect

--- a/LASS/src/LowPassFilter.cpp
+++ b/LASS/src/LowPassFilter.cpp
@@ -76,6 +76,18 @@ void LowPassFilter::reset()
 }
 
 //----------------------------------------------------------------------------//
+float LowPassFilter::get_state() const
+{
+	return y_hist->index_from_oldest(0);
+}
+
+void LowPassFilter::set_state(float s)
+{
+	y_hist->dequeue();
+	y_hist->enqueue(s);
+}
+
+//----------------------------------------------------------------------------//
 void LowPassFilter::xml_print()
 {
 

--- a/LASS/src/LowPassFilter.h
+++ b/LASS/src/LowPassFilter.h
@@ -92,6 +92,11 @@ public:
         **/
 	void xml_print();
 
+	/** Returns the current filter state (last output value). **/
+	float get_state() const;
+	/** Overwrites the filter state (for block-processing continuations). **/
+	void set_state(float s);
+
 private:
 
 	/**

--- a/LASS/src/Reverb.cpp
+++ b/LASS/src/Reverb.cpp
@@ -29,6 +29,10 @@
 #include "Reverb.h"
 #include "Types.h"
 
+#ifdef __APPLE__
+#include <vecLib/vDSP.h>
+#endif
+
 //----------------------------------------------------------------------------//
 
 
@@ -385,21 +389,61 @@ SoundSample *Reverb::do_reverb_SoundSample(SoundSample *inWave)
 }
 SoundSample *Reverb::do_reverb_SoundSample(SoundSample *inWave, Envelope *percentReverbinput)
 {
-  int i;
   SoundSample *outWave;
-  // delete percentReverb;
-  // percentReverb = new Envelope(*percentReverbinput);
 
   Envelope* temp = new Envelope(*percentReverbinput);
   delete percentReverb;
   percentReverb = temp;
-  // create new SoundSample
+
   outWave = new SoundSample(inWave->getSampleCount(),
 			    inWave->getSamplingRate());
 
-  for(i=0;i<inWave->getSampleCount();i++)
-    (*outWave)[i] = do_reverb((*inWave)[i],(float) i / inWave->getSampleCount()
-			      , percentReverb);
+#ifdef __APPLE__
+  // macOS buffer path: process entire audio buffer at once using
+  // do_filter_buffer (tight loops / vDSP SIMD) instead of per-sample calls.
+  long N = (long)inWave->getSampleCount();
+  float* inData  = &(*inWave)[0];
+  float* outData = &(*outWave)[0];
+
+  // Accumulate the 6 comb filter outputs.
+  vector<float> combSum(N, 0.0f);
+  vector<float> filterBuf(N);
+  for (int f = 0; f < REVERB_NUM_COMB_FILTERS; f++) {
+    lpcfilter[f]->do_filter_buffer(inData, filterBuf.data(), N);
+    vDSP_vadd(combSum.data(), 1, filterBuf.data(), 1,
+              combSum.data(), 1, (vDSP_Length)N);
+  }
+
+  // Scale by 1 / REVERB_NUM_COMB_FILTERS.
+  float scale = 1.0f / (float)REVERB_NUM_COMB_FILTERS;
+  vDSP_vsmul(combSum.data(), 1, &scale, combSum.data(), 1, (vDSP_Length)N);
+
+  // All-pass filter into outData.
+  apfilter->do_filter_buffer(combSum.data(), outData, N);
+
+  // Precompute envelope values and apply wet/dry mix:
+  //   out[i] = env[i] * apOut[i] + (1-env[i]) * in[i]
+  //          = env[i] * (apOut[i] - in[i]) + in[i]
+  float duration = percentReverb->getDuration();
+  float invN = 1.0f / (float)N;
+  vector<float> envVals(N);
+  for (long i = 0; i < N; i++)
+    envVals[i] = percentReverb->getValue((float)i * invN, duration);
+
+  // diff[i] = apOut[i] - in[i]  (vDSP_vsub: C = B - A)
+  vector<float> diff(N);
+  vDSP_vsub(inData, 1, outData, 1, diff.data(), 1, (vDSP_Length)N);
+
+  // outData[i] = envVals[i] * diff[i] + in[i]
+  vDSP_vma(envVals.data(), 1, diff.data(), 1, inData, 1,
+           outData, 1, (vDSP_Length)N);
+
+#else
+  for (int i = 0; i < inWave->getSampleCount(); i++)
+    (*outWave)[i] = do_reverb((*inWave)[i],
+                              (float)i / inWave->getSampleCount(),
+                              percentReverb);
+#endif
 
   return outWave;
 }


### PR DESCRIPTION
Uses the [vDSP library](https://developer.apple.com/documentation/accelerate/vdsp) that ships with macOS to perform more efficient vector operations for filter and reverb optimizations. I'm sure a more refined pass could be done over the whole code-base (or we could use a different vector op library that's better behaved cross-platform), but I think this is a good move for now. 