### PR TITLE
Add in-app "Check for Updates" via GitHub Releases

### DIFF
--- a/LASSIE/CMakeLists.txt
+++ b/LASSIE/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.25)
 project(LASSIE)
 message(STATUS "== LASSIE ==")
 
-find_package(Qt6 REQUIRED COMPONENTS Widgets Core Xml)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Core Xml Network)
 find_package(XercesC REQUIRED)
 
 set(CMAKE_AUTOUIC ON)
@@ -68,6 +68,7 @@ qt_add_executable(LASSIE
     src/widgets/Select.cpp src/widgets/Select.hpp
     src/widgets/MakeEnvelopeRow.cpp src/widgets/MakeEnvelopeRow.hpp
     src/widgets/generic/FunctionEntryRow.cpp src/widgets/generic/FunctionEntryRow.hpp
+    src/core/Updater.cpp src/core/Updater.hpp
 )
 
 target_precompile_headers(LASSIE PRIVATE <QtWidgets> <QtCore> <QtXml>)
@@ -76,6 +77,7 @@ target_link_libraries(LASSIE PRIVATE
     Qt6::Widgets
     Qt6::Core
     Qt6::Xml
+    Qt6::Network
     LASS
     XercesC::XercesC
 )
@@ -126,6 +128,15 @@ endif()
 
 target_compile_definitions(LASSIE PUBLIC "CMOD_BINARY=\"${CMOD_BINARY}\"")
 
+# Version info — sourced from DISSCOVersions.txt via the root CMakeLists.
+# Used by the in-app updater to compare against the latest GitHub release.
+target_compile_definitions(LASSIE PRIVATE
+    "DISSCO_VER_MAJOR=${DISSCO_VER_MAJOR}"
+    "DISSCO_VER_MINOR=${DISSCO_VER_MINOR}"
+    "DISSCO_VER_PATCH=${DISSCO_VER_PATCH}"
+    "DISSCO_VERSION_STR=\"${DISSCO_VERSION}\""
+)
+
 execute_process(
     COMMAND git rev-parse --abbrev-ref HEAD
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -137,6 +148,23 @@ if(NOT GIT_BRANCH)
     set(GIT_BRANCH "unknown")
 endif()
 target_compile_definitions(LASSIE PRIVATE "GIT_BRANCH=\"${GIT_BRANCH}\"")
+
+execute_process(
+    COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_COMMIT_SHA
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+if(NOT GIT_COMMIT_SHA)
+    set(GIT_COMMIT_SHA "unknown")
+endif()
+target_compile_definitions(LASSIE PRIVATE "GIT_COMMIT_SHA=\"${GIT_COMMIT_SHA}\"")
+
+# Canonical upstream repo for the updater. Kept in sync with the URLs in
+# packaging/Packaging.cmake (CPACK_NSIS_HELP_LINK / URL_INFO_ABOUT).
+set(DISSCO_GITHUB_REPO "cmp-illinois/DISSCO-2.2.0")
+target_compile_definitions(LASSIE PRIVATE "DISSCO_GITHUB_REPO=\"${DISSCO_GITHUB_REPO}\"")
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_definitions(LASSIE PRIVATE QT_NO_DEBUG_OUTPUT)

--- a/LASSIE/src/core/Updater.cpp
+++ b/LASSIE/src/core/Updater.cpp
@@ -1,0 +1,339 @@
+#include "Updater.hpp"
+
+#include <QApplication>
+#include <QDateTime>
+#include <QDesktopServices>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMessageBox>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QProgressDialog>
+#include <QPushButton>
+#include <QSettings>
+#include <QStandardPaths>
+#include <QSysInfo>
+
+namespace {
+
+QByteArray userAgent() {
+    return QStringLiteral("LASSIE/%1 (+https://github.com/%2)")
+        .arg(QStringLiteral(DISSCO_VERSION_STR), Updater::gitHubRepoSlug())
+        .toUtf8();
+}
+
+void applyGitHubHeaders(QNetworkRequest &req) {
+    req.setRawHeader("Accept", "application/vnd.github+json");
+    req.setRawHeader("X-GitHub-Api-Version", "2022-11-28");
+    req.setRawHeader("User-Agent", userAgent());
+}
+
+// Strip an optional leading 'v' and parse. QVersionNumber::fromString
+// stops at the first non-numeric character, so pre-release/build
+// suffixes ("-rc1", "-test", "+abc") fall away naturally.
+QVersionNumber parseTag(const QString &tag) {
+    QString trimmed = tag.trimmed();
+    if (trimmed.startsWith(QLatin1Char('v')) || trimmed.startsWith(QLatin1Char('V'))) {
+        trimmed.remove(0, 1);
+    }
+    return QVersionNumber::fromString(trimmed);
+}
+
+// Asset filename substring that identifies this platform's installer.
+// Must stay in sync with packaging/Packaging.cmake's CPACK_PACKAGE_FILE_NAME
+// and the workflow in .github/workflows/release.yml:
+//   macOS    DISSCO-<ver>-Darwin.dmg
+//   Linux    DISSCO-<ver>-Linux-<arch>.AppImage
+//   Windows  DISSCO-<ver>-Windows.exe
+QString platformAssetMarker() {
+#if defined(Q_OS_MACOS)
+    return QStringLiteral("-Darwin.dmg");
+#elif defined(Q_OS_WIN)
+    return QStringLiteral("-Windows.exe");
+#elif defined(Q_OS_LINUX)
+    return QStringLiteral(".AppImage");
+#else
+    return QString();
+#endif
+}
+
+}  // namespace
+
+QVersionNumber Updater::currentVersion() {
+    return QVersionNumber(DISSCO_VER_MAJOR, DISSCO_VER_MINOR, DISSCO_VER_PATCH);
+}
+
+QString Updater::currentCommit() {
+    return QStringLiteral(GIT_COMMIT_SHA);
+}
+
+QString Updater::gitHubRepoSlug() {
+    return QStringLiteral(DISSCO_GITHUB_REPO);
+}
+
+Updater::Updater(QWidget *uiParent)
+    : QObject(uiParent),
+      net_(new QNetworkAccessManager(this)),
+      uiParent_(uiParent) {}
+
+Updater::~Updater() = default;
+
+bool Updater::shouldAutoCheckNow() {
+    const QSettings s;
+    if (!s.value(kAutoCheckKey, false).toBool()) {
+        return false;
+    }
+    const QDateTime last = s.value(kLastCheckUtcKey).toDateTime();
+    return !last.isValid() ||
+           last.secsTo(QDateTime::currentDateTimeUtc()) >= 24 * 60 * 60;
+}
+
+void Updater::checkForUpdates(Trigger trigger) {
+    trigger_ = trigger;
+    QSettings().setValue(kLastCheckUtcKey, QDateTime::currentDateTimeUtc());
+
+    const QUrl url(QStringLiteral("https://api.github.com/repos/%1/releases/latest")
+                       .arg(gitHubRepoSlug()));
+    QNetworkRequest req(url);
+    applyGitHubHeaders(req);
+
+    QNetworkReply *reply = net_->get(req);
+    connect(reply, &QNetworkReply::finished, this, [this, reply] {
+        onReleaseReply(reply);
+    });
+}
+
+void Updater::onReleaseReply(QNetworkReply *reply) {
+    reply->deleteLater();
+
+    if (reply->error() != QNetworkReply::NoError) {
+        // 404 from /releases/latest just means no published release exists —
+        // common during early-stage projects. Treat as "up to date".
+        const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        if (status == 404) {
+            if (trigger_ == Trigger::Manual) {
+                QMessageBox::information(uiParent_, tr("Check for Updates"),
+                    tr("You're up to date.\n\nInstalled: %1\n\n"
+                       "No published releases on GitHub yet.")
+                        .arg(currentVersion().toString()));
+            }
+            return;
+        }
+        if (trigger_ == Trigger::Manual) {
+            reportError(tr("Couldn't reach GitHub: %1").arg(reply->errorString()));
+        }
+        return;
+    }
+
+    const QJsonObject obj = QJsonDocument::fromJson(reply->readAll()).object();
+
+    ReleaseInfo info;
+    info.tagName = obj.value("tag_name").toString();
+    info.version = parseTag(info.tagName);
+    info.releaseNotes = obj.value("body").toString();
+    info.htmlUrl = QUrl(obj.value("html_url").toString());
+
+    if (info.version.isNull()) {
+        if (trigger_ == Trigger::Manual) {
+            reportError(tr("Couldn't parse latest release tag '%1'.").arg(info.tagName));
+        }
+        return;
+    }
+
+    if (info.version <= currentVersion()) {
+        if (trigger_ == Trigger::Manual) {
+            QMessageBox::information(uiParent_, tr("Check for Updates"),
+                tr("You're up to date.\n\nInstalled: %1\nLatest released: %2")
+                    .arg(currentVersion().toString(), info.version.toString()));
+        }
+        return;
+    }
+
+    // Honour a prior "skip this version" choice on background checks.
+    if (trigger_ == Trigger::Auto &&
+        QSettings().value(kSkipVersionKey).toString() == info.version.toString()) {
+        return;
+    }
+
+    // Find the asset matching this OS.
+    const QString marker = platformAssetMarker();
+    if (!marker.isEmpty()) {
+        const QString archHint = QSysInfo::currentCpuArchitecture();
+        const QJsonArray assets = obj.value("assets").toArray();
+        for (const QJsonValue &v : assets) {
+            const QJsonObject a = v.toObject();
+            const QString name = a.value("name").toString();
+            if (!name.contains(marker)) continue;
+#if defined(Q_OS_LINUX)
+            // Prefer an arch-matched build when multiple AppImages exist.
+            if (!name.contains(archHint) && assets.size() > 1) continue;
+#endif
+            info.assetName = name;
+            info.assetUrl = QUrl(a.value("browser_download_url").toString());
+            info.assetSize = static_cast<qint64>(a.value("size").toDouble());
+            break;
+        }
+    }
+
+    if (!info.assetUrl.isValid()) {
+        QMessageBox::information(uiParent_, tr("Check for Updates"),
+            tr("Version %1 is available, but no installer was published for "
+               "this platform. Opening the release page.")
+                .arg(info.version.toString()));
+        QDesktopServices::openUrl(info.htmlUrl);
+        return;
+    }
+
+    presentReleaseDialog(info);
+}
+
+void Updater::presentReleaseDialog(const ReleaseInfo &info) {
+    QMessageBox box(uiParent_);
+    box.setWindowTitle(tr("Update Available"));
+    box.setIcon(QMessageBox::Information);
+    box.setText(tr("<b>LASSIE %1 is available.</b><br>You have %2.")
+                    .arg(info.version.toString(), currentVersion().toString()));
+    if (!info.releaseNotes.isEmpty()) {
+        QString notes = info.releaseNotes;
+        if (notes.size() > 1500) notes = notes.left(1500) + QStringLiteral("…");
+        box.setDetailedText(notes);
+    }
+
+    QPushButton *download     = box.addButton(tr("Download && Install"), QMessageBox::AcceptRole);
+    QAbstractButton *openPage = box.addButton(tr("Open Release Page"), QMessageBox::ActionRole);
+    QAbstractButton *skip     = box.addButton(tr("Skip This Version"), QMessageBox::DestructiveRole);
+    box.addButton(tr("Remind Me Later"), QMessageBox::RejectRole);
+    box.setDefaultButton(download);
+
+    box.exec();
+    QAbstractButton *clicked = box.clickedButton();
+    if (clicked == download) {
+        downloadAndInstall(info);
+    } else if (clicked == openPage) {
+        QDesktopServices::openUrl(info.htmlUrl);
+    } else if (clicked == skip) {
+        QSettings().setValue(kSkipVersionKey, info.version.toString());
+    }
+}
+
+void Updater::downloadAndInstall(const ReleaseInfo &info) {
+    const QString updatesDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
+                                + QStringLiteral("/updates");
+    QDir().mkpath(updatesDir);
+    const QString localPath = updatesDir + QLatin1Char('/') + info.assetName;
+
+    // Reuse a prior download if it's the right size.
+    if (info.assetSize > 0 && QFileInfo(localPath).size() == info.assetSize) {
+        launchInstaller(localPath);
+        return;
+    }
+
+    QFile *file = new QFile(localPath);
+    if (!file->open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        reportError(tr("Couldn't write to %1: %2").arg(localPath, file->errorString()));
+        delete file;
+        return;
+    }
+
+    QNetworkRequest req(info.assetUrl);
+    req.setRawHeader("User-Agent", userAgent());
+    req.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                     QNetworkRequest::NoLessSafeRedirectPolicy);
+    QNetworkReply *reply = net_->get(req);
+
+    QProgressDialog *progress = new QProgressDialog(
+        tr("Downloading %1…").arg(info.assetName),
+        tr("Cancel"), 0, 100, uiParent_);
+    progress->setWindowModality(Qt::WindowModal);
+    progress->setMinimumDuration(0);
+    progress->setAutoClose(true);
+
+    connect(reply, &QNetworkReply::downloadProgress, progress,
+            [progress](qint64 received, qint64 total) {
+        if (total > 0) {
+            progress->setMaximum(100);
+            progress->setValue(static_cast<int>((received * 100) / total));
+        } else {
+            progress->setMaximum(0);  // indeterminate
+        }
+    });
+    connect(reply, &QNetworkReply::readyRead, file, [reply, file] {
+        file->write(reply->readAll());
+    });
+    connect(progress, &QProgressDialog::canceled, reply, &QNetworkReply::abort);
+
+    connect(reply, &QNetworkReply::finished, this,
+            [this, reply, file, progress, info, localPath] {
+        file->write(reply->readAll());
+        file->close();
+        progress->close();
+        progress->deleteLater();
+
+        const auto err = reply->error();
+        const qint64 onDisk = QFileInfo(localPath).size();
+        reply->deleteLater();
+        delete file;
+
+        if (err == QNetworkReply::OperationCanceledError) {
+            QFile::remove(localPath);
+            return;
+        }
+        if (err != QNetworkReply::NoError) {
+            QFile::remove(localPath);
+            reportError(tr("Download failed: %1").arg(reply->errorString()));
+            return;
+        }
+        if (info.assetSize > 0 && onDisk != info.assetSize) {
+            QFile::remove(localPath);
+            reportError(tr("Download size mismatch (got %1 bytes, expected %2).")
+                            .arg(onDisk).arg(info.assetSize));
+            return;
+        }
+        launchInstaller(localPath);
+    });
+}
+
+void Updater::launchInstaller(const QString &localPath) {
+#if defined(Q_OS_MACOS)
+    // Mount the DMG in Finder; user drags LASSIE.app into Applications.
+    if (!QDesktopServices::openUrl(QUrl::fromLocalFile(localPath))) {
+        reportError(tr("Couldn't open downloaded installer at %1").arg(localPath));
+        return;
+    }
+    QMessageBox::information(uiParent_, tr("Install LASSIE Update"),
+        tr("The disk image has been mounted. Drag <b>LASSIE</b> into your "
+           "Applications folder, then relaunch."));
+
+#elif defined(Q_OS_WIN)
+    // Launch the NSIS installer; it'll elevate, uninstall the current
+    // version, and install the new one. We quit so it can replace LASSIE.exe.
+    if (!QDesktopServices::openUrl(QUrl::fromLocalFile(localPath))) {
+        reportError(tr("Couldn't launch installer at %1").arg(localPath));
+        return;
+    }
+    QMessageBox::information(uiParent_, tr("Install LASSIE Update"),
+        tr("The installer has been launched. LASSIE will now quit so the "
+           "installer can replace it."));
+    QApplication::quit();
+
+#else
+    // Linux (and unknown OSes): no automatic AppImage swap — too many
+    // failure modes (PID race, alternate install locations, mounted
+    // read-only filesystems). Show the file in a file manager and let
+    // the user move it over their existing AppImage.
+    QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(localPath).absolutePath()));
+    QMessageBox::information(uiParent_, tr("Update Downloaded"),
+        tr("Saved to:\n\n%1\n\nReplace your existing AppImage with this "
+           "file and relaunch.").arg(localPath));
+#endif
+}
+
+void Updater::reportError(const QString &message) {
+    if (trigger_ == Trigger::Auto) return;  // silent on background checks
+    QMessageBox::warning(uiParent_, tr("Check for Updates"), message);
+}

--- a/LASSIE/src/core/Updater.hpp
+++ b/LASSIE/src/core/Updater.hpp
@@ -1,0 +1,75 @@
+#ifndef UPDATER_HPP
+#define UPDATER_HPP
+
+#include <QObject>
+#include <QString>
+#include <QUrl>
+#include <QVersionNumber>
+
+class QNetworkAccessManager;
+class QNetworkReply;
+class QWidget;
+
+/**
+ * @brief In-app "Check for Updates" client backed by the GitHub Releases API.
+ *
+ * GETs /releases/latest, parses the tag as a QVersionNumber, and compares
+ * it against the build's compile-time DISSCO_VERSION. If newer, offers to
+ * download the matching platform asset (DMG / AppImage / EXE) and hands it
+ * to the OS to install.
+ *
+ * Triggered manually from the Help menu, and optionally on app startup
+ * once per 24h.
+ */
+class Updater : public QObject {
+    Q_OBJECT
+    public:
+        /// Whether the check is user-initiated (chatty) or background (silent).
+        enum class Trigger { Manual, Auto };
+
+        /// Build the updater, parented to the window that owns its dialogs.
+        explicit Updater(QWidget *uiParent);
+        ~Updater() override;
+
+        // QSettings keys (flat camelCase to match the rest of the app).
+        static constexpr const char *kAutoCheckKey = "updaterAutoCheck";
+        static constexpr const char *kLastCheckUtcKey = "updaterLastCheckUtc";
+        static constexpr const char *kSkipVersionKey = "updaterSkipVersion";
+
+        /// Build's compile-time version (from DISSCOVersions.txt).
+        static QVersionNumber currentVersion();
+        /// Build's git HEAD commit SHA, or "unknown".
+        static QString currentCommit();
+        /// "owner/repo" slug for the GitHub repo being polled.
+        static QString gitHubRepoSlug();
+
+        /// Run a release check. Safe to call from the GUI thread.
+        void checkForUpdates(Trigger trigger);
+
+        /// True iff auto-check is on AND it has been >= 24h since the
+        /// last check. MainWindow polls this on startup.
+        static bool shouldAutoCheckNow();
+
+    private:
+        struct ReleaseInfo {
+            QVersionNumber version;
+            QString tagName;
+            QString releaseNotes;
+            QUrl htmlUrl;
+            QUrl assetUrl;
+            QString assetName;
+            qint64 assetSize = -1;
+        };
+
+        void onReleaseReply(QNetworkReply *reply);
+        void presentReleaseDialog(const ReleaseInfo &info);
+        void downloadAndInstall(const ReleaseInfo &info);
+        void launchInstaller(const QString &localPath);
+        void reportError(const QString &message);
+
+        QNetworkAccessManager *net_;
+        QWidget *uiParent_;
+        Trigger trigger_ = Trigger::Manual;
+};
+
+#endif  // UPDATER_HPP

--- a/LASSIE/src/main.cpp
+++ b/LASSIE/src/main.cpp
@@ -8,6 +8,13 @@ void registerAllFunctions();
 
 int main(int argc, char *argv[])
 {
+    // QSettings (used here and in the Updater) needs stable org/app
+    // metadata; otherwise its on-disk location is platform-default and
+    // varies between binaries. Set before QApplication is constructed.
+    QCoreApplication::setOrganizationName("DISSCO");
+    QCoreApplication::setOrganizationDomain("dissco.illinois.edu");
+    QCoreApplication::setApplicationName("LASSIE");
+
     QApplication a(argc, argv);
     registerAllFunctions();
     Inst *m = Inst::instance();

--- a/LASSIE/src/windows/MainWindow.cpp
+++ b/LASSIE/src/windows/MainWindow.cpp
@@ -7,6 +7,7 @@
 #include "PostWindow.hpp"
 
 #include "../core/project_struct.hpp"
+#include "../core/Updater.hpp"
 
 #include <QApplication>
 #include <QMenuBar>
@@ -38,6 +39,7 @@
 #include <QAction>
 #include <QKeyEvent>
 #include <QStandardPaths>
+#include <QTimer>
 
 MainWindow *MainWindow::instance_ = nullptr;
 
@@ -108,6 +110,15 @@ MainWindow::MainWindow(Inst* m)
     header->setSectionResizeMode(2, QHeaderView::ResizeToContents);
     connect(Inst::get_project_manager(), &ProjectManager::dataModified,
             this, [this]{ setWindowModified(true); });
+
+    updater_ = new Updater(this);
+    if (Updater::shouldAutoCheckNow()) {
+        // Defer until the event loop is running so the main window has
+        // painted before any dialog can appear.
+        QTimer::singleShot(0, this, [this]() {
+            updater_->checkForUpdates(Updater::Trigger::Auto);
+        });
+    }
 }
 
 //MainWindow::~MainWindow() = default;
@@ -469,12 +480,31 @@ void MainWindow::createActions()
         QMessageBox::about(this, tr("About LASSIE"),
             tr("LASSIE (Library for Algorithmic Sound Synthesis and Interactive Exploration) "
                "is a tool for creating and manipulating sound synthesis algorithms.\n\n"
-               "Branch: ") + GIT_BRANCH);
+               "Version: %1\nBranch: %2\nCommit: %3")
+                .arg(Updater::currentVersion().toString(),
+                     QString::fromLatin1(GIT_BRANCH),
+                     Updater::currentCommit().left(7)));
     });
 
     aboutQtAct = new QAction(tr("About &Qt"), this);
     aboutQtAct->setStatusTip(tr("Show the Qt library's About box"));
     connect(aboutQtAct, &QAction::triggered, qApp, &QApplication::aboutQt);
+
+    checkForUpdatesAct = new QAction(tr("Check for &Updates..."), this);
+    checkForUpdatesAct->setStatusTip(tr("Check GitHub for a newer LASSIE release"));
+    connect(checkForUpdatesAct, &QAction::triggered, this, [this]() {
+        if (updater_) {
+            updater_->checkForUpdates(Updater::Trigger::Manual);
+        }
+    });
+
+    autoCheckUpdatesAct = new QAction(tr("Check for Updates on &Startup"), this);
+    autoCheckUpdatesAct->setStatusTip(tr("Automatically check for updates once per day on launch"));
+    autoCheckUpdatesAct->setCheckable(true);
+    autoCheckUpdatesAct->setChecked(QSettings().value(Updater::kAutoCheckKey, false).toBool());
+    connect(autoCheckUpdatesAct, &QAction::toggled, this, [](const bool on) {
+        QSettings().setValue(Updater::kAutoCheckKey, on);
+    });
 }
 
 void MainWindow::enableProjectActions(const bool enabled) const {
@@ -517,6 +547,9 @@ void MainWindow::createMenus()
     viewMenu->addAction(showMarkovAct);
 
     helpMenu = menuBar()->addMenu(tr("&Help"));
+    helpMenu->addAction(checkForUpdatesAct);
+    helpMenu->addAction(autoCheckUpdatesAct);
+    helpMenu->addSeparator();
     helpMenu->addAction(aboutAct);
     helpMenu->addAction(aboutQtAct);
 }

--- a/LASSIE/src/windows/MainWindow.hpp
+++ b/LASSIE/src/windows/MainWindow.hpp
@@ -17,6 +17,7 @@ QT_END_NAMESPACE
 class EnvelopeLibraryWindow;
 class MarkovModelLibraryWindow; //nhi: more descriptive than MarkovWindow
 class ProjectView;
+class Updater;
 
 /**
  * @brief Top-level Qt main window for LASSIE.
@@ -139,6 +140,8 @@ class MainWindow : public QMainWindow
         QAction *showMarkovAct = nullptr;
         QAction *aboutAct = nullptr;
         QAction *aboutQtAct = nullptr;
+        QAction *checkForUpdatesAct = nullptr;
+        QAction *autoCheckUpdatesAct = nullptr;
 
         // Menus
         QMenu *fileMenu = nullptr;
@@ -158,6 +161,7 @@ class MainWindow : public QMainWindow
         ProjectView* projectView = nullptr;
         
         Inst *main_;
+        Updater *updater_ = nullptr;
         static MainWindow *instance_;
 };
 


### PR DESCRIPTION
## What

Adds an in-app **Check for Updates** system to LASSIE, backed by the GitHub Releases API.

- New `Updater` service (`LASSIE/src/core/Updater.{hpp,cpp}`): queries `/releases/latest`, parses the tag as a `QVersionNumber`, and compares it against the build's compile-time `DISSCO_VERSION`.
- If a newer release exists, it picks the asset matching the current OS (`-Darwin.dmg` / `.AppImage` / `-Windows.exe`), downloads it with a progress dialog, verifies the size, and hands it to the OS to install.
  - **macOS**: mounts the DMG, prompts the user to drag LASSIE into Applications.
  - **Windows**: launches the NSIS installer and quits.
  - **Linux**: saves the AppImage, reveals it in the file manager, prompts the user to replace their existing image (no automatic in-place swap — too many failure modes).
- Help menu gains **Check for Updates...** plus an opt-in, checkable **Check for Updates on Startup** (throttled to once per 24h via `QSettings`).
- "Skip This Version" / "Open Release Page" / "Remind Me Later" options on the update dialog.
- About dialog now reports version, branch, and short commit SHA (useful for bug reports).

## Why

Gives users a one-click path to stay current instead of manually watching the releases page. CMOD ships embedded inside each release artifact (the macOS `.app`, the AppImage, and the NSIS install dir), so updating LASSIE updates CMOD atomically — a single update path covers both.

## Implementation notes

- `LASSIE/CMakeLists.txt` now links `Qt6::Network` and passes `DISSCO_VER_*`, `DISSCO_VERSION_STR`, `GIT_COMMIT_SHA`, and `DISSCO_GITHUB_REPO` as compile definitions.
- `main.cpp` sets stable `QCoreApplication` org/app metadata so `QSettings` has a well-defined location.
- The auto-check is deferred via `QTimer::singleShot(0, ...)` so the main window paints before any dialog appears.

## Reviewer caveats (behavior, not bugs)

- **Draft releases are invisible**: `/releases/latest` excludes drafts/pre-releases, and `release.yml` currently publishes with `draft: true`. The updater correctly reports "no published releases yet" (HTTP 404) until a release is un-drafted. Un-drafting a release is what arms the feature.
- **Windows installers aren't produced yet**: the `windows` job in `release.yml` is `if: false`, so no `-Windows.exe` asset is uploaded. The updater handles a missing platform asset gracefully (falls back to opening the release page).
- **Auto-check stamps its timestamp at the start of the check**, so a launch while offline won't retry for 24h — intentional, to avoid hammering on every cold launch.
- **"Skip This Version" only suppresses the automatic check**, not a manual one — a manual "Check for Updates" always re-shows.

## Testing

- Builds clean on macOS (Qt 6, Ninja, Release).
- Manually verified the Help menu item triggers the check; against the current draft-only release state it correctly reports no published releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)