### PR TITLE
lass: pass arguments to `MultiTrack` as const

### DIFF
--- a/LASS/src/Collection.cpp
+++ b/LASS/src/Collection.cpp
@@ -170,6 +170,26 @@ template<class T> int Collection<T>::size()
     return (int) vector_.size();
 }
 
+//----------------------------------------------------------------------------//
+template<class T> int Collection<T>::size() const
+{
+    return (int) vector_.size();
+}
+
+//----------------------------------------------------------------------------//
+template<class T> const T& Collection<T>::get(int index) const
+{
+    if ( (index >= 0) && (index < (int) vector_.size()))
+    {
+        return vector_[index];
+    }
+    else
+    {
+        cerr << "ERROR: Collection.get() Index out of bounds: " << index << endl;
+        return vector_[0];
+    }
+}
+
 
 //----------------------------------------------------------------------------//
 template<class T> void Collection<T>::sortCollection()

--- a/LASS/src/Collection.h
+++ b/LASS/src/Collection.h
@@ -121,18 +121,26 @@ public:
     
     /**
     *	Returns the size of this collection.
-    *	This is a 0-based array so the entries 
+    *	This is a 0-based array so the entries
     *	are indexed from 0 to (size-1).
     *   \return The size of the collection
     **/
     int size();
+    int size() const;
+
+    /**
+    *	\exception IndexOutOfBoundsException
+    *	\param index An integer specifying which element to retrieve
+    *	\return A const reference to the element at the specified index
+    **/
+    const T& get(int index) const;
 
     /**
     *	This sorts the collection.
     *	\note only use this function if template type of this collection has well defined operator< , operator== , and operator> . Examples of this are standard types like int and float, as well as custom types like LinearInterpolatorEntry.
     **/
     void sortCollection();
-    
+
     /**
     *	Returns an iterator over the elements in this collection.
     *   \return an iteration

--- a/LASS/src/MultiTrack.cpp
+++ b/LASS/src/MultiTrack.cpp
@@ -57,16 +57,14 @@ MultiTrack::MultiTrack(
 }
 
 //----------------------------------------------------------------------------//
-MultiTrack::MultiTrack(MultiTrack& mt) : Collection<Track*>(mt)
+MultiTrack::MultiTrack(const MultiTrack& mt) : Collection<Track*>(mt)
 {
-    // copy every track from mt to this object.
-    Iterator<Track*> it = mt.iterator();
-    while (it.hasNext())
-        add(new Track(*it.next()));
+    for (int i = 0; i < mt.size(); i++)
+        add(new Track(*mt.get(i)));
 }
 
 //----------------------------------------------------------------------------//
-MultiTrack& MultiTrack::operator=(MultiTrack& mt)
+MultiTrack& MultiTrack::operator=(const MultiTrack& mt)
 {
     if ( this != &mt) // beware of self assignment
     {
@@ -74,16 +72,14 @@ MultiTrack& MultiTrack::operator=(MultiTrack& mt)
         Iterator<Track*> it = iterator();
         while(it.hasNext())
             delete it.next();
-        
+
         // clear this object
         clear();
-        
-        // copy every track from mt to this object.
-        it = mt.iterator();
-        while (it.hasNext())
-            add(new Track(*it.next()));
+
+        for (int i = 0; i < mt.size(); i++)
+            add(new Track(*mt.get(i)));
     }
-    
+
     return *this;
 }
 

--- a/LASS/src/MultiTrack.h
+++ b/LASS/src/MultiTrack.h
@@ -73,18 +73,16 @@ public:
     
     /**
     *	This is a copy Constructor.
-    *	\todo The argument should be const.
     *	\param mt The MultiTrack to copy
     **/
-    MultiTrack(MultiTrack& mt);
-    
+    MultiTrack(const MultiTrack& mt);
+
     /**
     *	This is an overloaded assignment operator.
-    *	\todo The argument should be const.
     *	\param mt The MultiTrack to assign.
     *	\return A MultiTrack
     **/
-    MultiTrack& operator=(MultiTrack& mt);
+    MultiTrack& operator=(const MultiTrack& mt);
     
     /**
     *	This is a destructor.


### PR DESCRIPTION
`Collection` nowhas a size() and get() function to support a range-based loop, since iterator loops require non-const access (and a loop is necessary for the `MultiTrack` class)