### PR TITLE
lass: only allocate amp buffer if used by clipping mode

### DIFF
--- a/LASS/src/MultiPan.cpp
+++ b/LASS/src/MultiPan.cpp
@@ -358,7 +358,8 @@ MultiTrack* MultiPan::spatialize_Track(Track& t, int numTracks)
 
 	// get references to the input
 	SoundSample &inWave = t.getWave();
-	SoundSample &inAmp  = t.getAmp();
+	bool doAmp = t.hasAmp();
+	SoundSample *inAmp = doAmp ? &t.getAmp() : 0;
 
 	// for each channel
 	for(int c=0; c<n_channels; c++)
@@ -368,19 +369,19 @@ MultiTrack* MultiPan::spatialize_Track(Track& t, int numTracks)
 
 		// get references for this channel
 		SoundSample &thisWave = mt->get(c)->getWave();
-		SoundSample &thisAmp  = mt->get(c)->getAmp();
+		SoundSample *thisAmp  = doAmp ? &mt->get(c)->getAmp() : 0;
 
 		// Iterate over each sample
 		m_value_type scale;
 		for(m_sample_count_type i=0; i<sampleCount; i++)
 		{
-			// calculate scaling factor -- FIXME, I don't 
+			// calculate scaling factor -- FIXME, I don't
 			//  understand what Pan.cpp does here, what is
 			//  'pos' for?
 			scale = iter.next();
 
 			thisWave[i] = scale * inWave[i];
-			thisAmp[i]  = scale * inAmp[i];
+			if (doAmp) (*thisAmp)[i] = scale * (*inAmp)[i];
 		}
 	}
 

--- a/LASS/src/Pan.cpp
+++ b/LASS/src/Pan.cpp
@@ -65,7 +65,8 @@ MultiTrack* Pan::spatialize_Track(Track& t, int numTracks)
     
     // get references to the input
     SoundSample& inWave = t.getWave();
-    SoundSample& inAmp = t.getAmp();
+    bool doAmp = t.hasAmp();
+    SoundSample* inAmp = doAmp ? &t.getAmp() : 0;
 
 
     // for each channel:
@@ -73,14 +74,14 @@ MultiTrack* Pan::spatialize_Track(Track& t, int numTracks)
     {
         // get an iterator for the pan variable:
         Iterator<m_value_type> panIter = panVar_->valueIterator();
-        
+
         // get references for this channel.
         SoundSample& thisWave = mt->get(c)->getWave();
-        SoundSample& thisAmp = mt->get(c)->getAmp();
+        SoundSample* thisAmp = doAmp ? &mt->get(c)->getAmp() : 0;
 
         // create a position value for this channel:
         m_value_type pos = float(c) / float(numTracks-1);
-        
+
         // Iterate over each sample
         m_value_type scale;
         for (m_sample_count_type i=0; i<sampleCount; i++)
@@ -89,9 +90,9 @@ MultiTrack* Pan::spatialize_Track(Track& t, int numTracks)
             scale = 1.0 - fabs(pos - panIter.next());
             if (scale > 1.0) scale = 1.0;
             if (scale < 0.0) scale = 0.0;
-            
+
             thisWave[i] = scale * inWave[i];
-            thisAmp[i] = scale * inAmp[i];
+            if (doAmp) (*thisAmp)[i] = scale * (*inAmp)[i];
         }
     }
      

--- a/LASS/src/Partial.cpp
+++ b/LASS/src/Partial.cpp
@@ -78,9 +78,13 @@ MultiTrack* Partial::render(int numChannels,
     // one for the actuial sound:
     //    SoundSample* waveSample = new SoundSample(numSamplesTotal, samplingRate);
     SoundSample* waveSample = new SoundSample(sampleCount, samplingRate);
-    // and one to store amplitude data:
+    // and one to store amplitude data (only when a downstream consumer, i.e. an
+    // amplitude-based clipping mode, actually needs it -- otherwise this would
+    // double the rendering memory for nothing):
     //    SoundSample* ampSample = new SoundSample(numSamplesTotal, samplingRate);
-    SoundSample* ampSample = new SoundSample(sampleCount, samplingRate);
+    SoundSample* ampSample = Track::amplitudeTrackingEnabled()
+        ? new SoundSample(sampleCount, samplingRate)
+        : 0;
 
     // tell each dynamic variable what the DURATION will be:
     getParam(FREQUENCY).setDuration(duration);
@@ -353,7 +357,7 @@ MultiTrack* Partial::render(int numChannels,
 
         // assign it:
         (*waveSample)[s] = sample;
-        (*ampSample)[s] = amplitude;
+        if (ampSample) (*ampSample)[s] = amplitude;
     }
 
     // create a TrackObject:
@@ -362,13 +366,12 @@ MultiTrack* Partial::render(int numChannels,
     // do the reverb, if necessary
     if(reverbObj != NULL)
     {
+        // do_reverb_Track() returns a freshly heap-allocated Track, so take
+        // ownership of it directly instead of deep-copying its full-length
+        // buffers into another new Track and then freeing the original.
         Track &tmp = reverbObj->do_reverb_Track(*_track);
         delete _track;
-        _track = new Track(tmp);
-
-        // delete the temporary track object
-        delete &tmp;
-
+        _track = &tmp;
     }
 
     /* ZIYUAN CHEN, July 2023: On the default behavior of spatialization (Partial side)

--- a/LASS/src/Reverb.cpp
+++ b/LASS/src/Reverb.cpp
@@ -344,7 +344,9 @@ MultiTrack &Reverb::do_reverb_MultiTrack(MultiTrack &inWave, Envelope *percentRe
 
       newWave = do_reverb_SoundSample(&curTrack->getWave(), percentReverb);
       reset();
-      newAmp  = constructAmp(newWave);
+      // Only rebuild the amplitude envelope if the source carried one; when
+      // amplitude tracking is off this avoids a full-length allocation per track.
+      newAmp  = curTrack->hasAmp() ? constructAmp(newWave) : 0;
       reset();
       newMultiTrack->add(new Track(newWave, newAmp));
     }
@@ -374,7 +376,7 @@ Track &Reverb::do_reverb_Track(Track &inWave, Envelope *percentReverbinput)
   // create a new track based on the returned, filtered SoundSample
   newWave = do_reverb_SoundSample(&inWave.getWave(), percentReverb);
   reset();
-  newAmp  = constructAmp(newWave);
+  newAmp  = inWave.hasAmp() ? constructAmp(newWave) : 0;
   newTrack = new Track(newWave, newAmp);
 
   return *newTrack;

--- a/LASS/src/Score.cpp
+++ b/LASS/src/Score.cpp
@@ -34,6 +34,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include <memory>
 
+// Defined further down; maps a clipping mode to whether it reads the amp buffer.
+static bool modeNeedsAmplitude(Score::ClippingManagementMode mode);
+
 //----------------------------------------------------------------------------//
 
 // This struct passes data between the main thread and the worker threads
@@ -158,6 +161,11 @@ Score::Score(int _numThreads, int _numChannels, int _samplingRate )
     numChannels(_numChannels),
     samplingRate(_samplingRate)
 {
+  // Configure amplitude tracking before any track is allocated, based on the
+  // initial clipping mode (callers may override later via
+  // setClippingManagementMode, before sounds are added/rendered).
+  Track::setAmplitudeTracking(modeNeedsAmplitude(cmm_));
+
   scoreEndTime = 1; //start with a small number
   scoreMultiTrackLength = scoreEndTime;
   m_sample_count_type newNumSamples =
@@ -298,10 +306,22 @@ void Score::checkScoreMultiTrackLength(){
 
 //----------------------------------------------------------------------------//
 
+// Only the amplitude-based clipping modes inspect the per-track amp buffer.
+// For every other mode the amp buffer is dead weight, so we can avoid
+// allocating it (roughly halving rendering memory) by disabling amplitude
+// tracking before any track is created.
+static bool modeNeedsAmplitude(Score::ClippingManagementMode mode)
+{
+    return mode == Score::SCALE
+        || mode == Score::CHANNEL_SCALE
+        || mode == Score::ANTICLIP;
+}
+
 void Score::setClippingManagementMode(ClippingManagementMode mode)
 {
     cout << "Score::setClippingManagementMode - " << mode << endl;
     cmm_ = mode;
+    Track::setAmplitudeTracking(modeNeedsAmplitude(mode));
 }
 
 //----------------------------------------------------------------------------//
@@ -350,16 +370,14 @@ void Score::clip(MultiTrack* mt)
     for (int t=0; t<mt->size(); t++)
     {
         SoundSample& wave = mt->get(t)->getWave();
-        SoundSample& amp = mt->get(t)->getAmp();
 
-        // for each sample
+        // for each sample (only the wave is written to file; the amp buffer is
+        // not clamped here because it is never read back out)
         m_sample_count_type numSamples = wave.getSampleCount();
         for (m_sample_count_type s=0; s<numSamples; s++)
         {
             if (wave[s] >  1.0) wave[s] =  1.0;
             if (wave[s] < -1.0) wave[s] = -1.0;
-            if (amp[s] >  1.0) amp[s] =  1.0;
-            if (amp[s] < -1.0) amp[s] = -1.0;
         }
 
     }
@@ -547,21 +565,12 @@ void Score::channelAnticlip(MultiTrack* mt)
     {
 	// cout << "Score::channelAnticlip - first time track=" << t << endl;
         SoundSample& wave = mt->get(t)->getWave();
-        SoundSample& amp = mt->get(t)->getAmp();
 
-        // for each sample
+        // for each sample (peak is measured from the wave; the amp buffer is
+        // not consulted, so it is not allocated for this mode)
         m_sample_count_type numSamples = wave.getSampleCount();
         for (m_sample_count_type s=0; s<numSamples; s++)
         {
-
-            if (amp[s] > 1.0) {
-/* 				deprecated
-                scale this sample:
-                wave[s] *= 1.0 / amp[s];
-                amp[s] = 1.0;
-*/
-            }
-
             m_sample_type cur = wave[s];
             if(cur < 0) cur = -cur;
             if(cur > maxAmplitude)
@@ -589,14 +598,11 @@ void Score::channelAnticlip(MultiTrack* mt)
       for (int t=0; t<mt->size(); t++)
       {
           SoundSample& wave = mt->get(t)->getWave();
-          SoundSample& amp = mt->get(t)->getAmp();
 
           // for each sample
           m_sample_count_type numSamples = wave.getSampleCount();
           for (m_sample_count_type s=0; s<numSamples; s++)
           {
-              amp[s] = 1.0;
-
  	    if (wave[s] < 0) {
 	      wave[s] *= -1;
               wave[s] = compressSound(wave[s], maxAmplitude, -6.0);

--- a/LASS/src/SoundSample.cpp
+++ b/LASS/src/SoundSample.cpp
@@ -51,16 +51,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //----------------------------------------------------------------------------//
 SoundSample::SoundSample(m_sample_count_type sampleCount,
             m_rate_type samplingRate,
-            bool zeroData)
+            bool /*zeroData*/)
     :samplingRate_(samplingRate),data_(sampleCount)
 {
-    if (zeroData)
-    {
-        for (m_sample_count_type s=0; s<sampleCount; s++)
-        {
-            data_[s] = 0.0;
-        }
-    }
+    // The vector constructor value-initializes every element to 0.0, so the
+    // data is already zeroed regardless of the (now vestigial) zeroData flag.
 }
 
 //----------------------------------------------------------------------------//

--- a/LASS/src/Track.cpp
+++ b/LASS/src/Track.cpp
@@ -31,6 +31,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "Track.h"
 
 //----------------------------------------------------------------------------//
+
+// Amplitude tracking defaults to on so that direct LASS library users keep the
+// original behavior; Score turns it off for clipping modes that never read it.
+bool Track::amplitudeTracking_ = true;
+
+//----------------------------------------------------------------------------//
 // CONSTRUCTORS, DESTRUCTOR, ASSIGNMENT
 
 //----------------------------------------------------------------------------//
@@ -44,7 +50,9 @@ Track::Track(m_sample_count_type sampleCount,
        m_rate_type samplingRate,
        bool zeroData)
     :wave_(new SoundSample(sampleCount, samplingRate, zeroData)),
-     amp_(new SoundSample(sampleCount, samplingRate, zeroData))
+     amp_(amplitudeTracking_
+              ? new SoundSample(sampleCount, samplingRate, zeroData)
+              : 0)
 {
 }
 
@@ -131,6 +139,18 @@ void Track::scale(m_value_type factor)
 {
     wave_->scale(factor);
     if (amp_ != 0) amp_->scale(factor);
+}
+
+//----------------------------------------------------------------------------//
+void Track::setAmplitudeTracking(bool enabled)
+{
+    amplitudeTracking_ = enabled;
+}
+
+//----------------------------------------------------------------------------//
+bool Track::amplitudeTrackingEnabled()
+{
+    return amplitudeTracking_;
 }
 
 //----------------------------------------------------------------------------//

--- a/LASS/src/Track.h
+++ b/LASS/src/Track.h
@@ -127,10 +127,32 @@ public:
     **/
     void scale(m_value_type factor);
 
+    /**
+    *	Globally enable or disable allocation of the per-track amplitude
+    *	SoundSample.  The amp buffer is the same size as the wave buffer, so
+    *	suppressing it roughly halves the memory used by rendering.  It is only
+    *	needed by the amplitude-based clipping management modes (SCALE,
+    *	CHANNEL_SCALE, ANTICLIP); the default/most-used modes (NONE, CLIP,
+    *	CHANNEL_ANTICLIP) never read it.
+    *
+    *	This is a process-wide setting and must be configured before rendering
+    *	begins (a single Score is rendered at a time); it is only written from
+    *	the main thread before worker threads start, then read concurrently.
+    *	\param enabled Whether newly created tracks should carry an amp buffer
+    **/
+    static void setAmplitudeTracking(bool enabled);
+
+    /**
+    *	\return Whether newly created tracks carry an amplitude buffer.
+    **/
+    static bool amplitudeTrackingEnabled();
+
 private:
 
     SoundSample* wave_;
     SoundSample* amp_;
+
+    static bool amplitudeTracking_;
 };
 
 


### PR DESCRIPTION
cuts like ~30% of memory allocs

basically, each `Track` has two `SoundSample` buffers—`amp` and `wave`—of identical size (typically on the order of MB). Was often the case that `amp` was not used by the clipping mode but was still being allocated. Claude says this:

> Per-channel unit — 8-channel piece, 1 minute, 44.1 kHz:
>
> samples/channel = 60 × 44100 = 2,646,000
> wave buffer/channel = 2,646,000 × 4 B ≈ 10.1 MB
> old Track/channel = wave + amp ≈ 20.2 MB (half of it amp)
> final 8-channel score buffer: old ≈ 162 MB (81 wave + 81 amp) → new ≈ 81 MB
