### PR TITLE
lassie: replace regexp-based inline xml writer

### DIFF
--- a/LASSIE/src/widgets/ProjectViewController.cpp
+++ b/LASSIE/src/widgets/ProjectViewController.cpp
@@ -99,6 +99,35 @@ ProjectView::~ProjectView() {
     }
 }
 
+/** Re-emits a parsed DOM node through the QXmlStreamWriter. Doing this 
+ * through the writer allows us to write inline xml (as in <Fun/> blocks) properly.
+ */ 
+static void writeDomNode(QXmlStreamWriter& xmlWriter, const QDomNode& node) {
+    if (node.isElement()) {
+        QDomElement element = node.toElement();
+        xmlWriter.writeStartElement(element.tagName());
+        QDomNamedNodeMap attrs = element.attributes();
+        for (int i = 0; i < attrs.count(); ++i) {
+            QDomAttr attr = attrs.item(i).toAttr();
+            xmlWriter.writeAttribute(attr.name(), attr.value());
+        }
+        for (QDomNode child = element.firstChild(); !child.isNull();
+             child = child.nextSibling()) {
+            writeDomNode(xmlWriter, child);
+        }
+        xmlWriter.writeEndElement();
+    } else if (node.isCDATASection()) {
+        xmlWriter.writeCDATA(node.toCDATASection().data());
+    } else if (node.isText()) {
+        // Skip whitespace-only text nodes (formatting between elements) so the
+        // output stays compact, but keep real values like "STEREO" or "250".
+        const QString text = node.toText().data();
+        if (!text.trimmed().isEmpty()) {
+            xmlWriter.writeCharacters(text);
+        }
+    }
+}
+
 // Function to write XML Formatting
 void ProjectView::writeInlineXml(QXmlStreamWriter& xmlWriter, const QString& xmlString) {
     QDomDocument tempDoc;
@@ -106,28 +135,10 @@ void ProjectView::writeInlineXml(QXmlStreamWriter& xmlWriter, const QString& xml
     if (tempDoc.setContent(wrappedXml)) {
         QDomNodeList children = tempDoc.documentElement().childNodes();
         for (int i = 0; i < children.count(); ++i) {
-            QDomNode node = children.at(i);
-            if (node.isElement()) {
-                // Write raw XML
-                QString rawXml;
-                QTextStream stream(&rawXml);
-                node.save(stream, 0);
-                rawXml.remove(QRegularExpression("[\\n\\t\\r]+"));
-                rawXml.replace(QRegularExpression(">\\s+<"), "><");
-                xmlWriter.writeCharacters("");
-                xmlWriter.device()->write(rawXml.toUtf8());
-            } else {
-                // Write plain text (like "1 - ") normally so it's safely escaped
-                xmlWriter.writeCharacters(node.nodeValue());
-            }
+            writeDomNode(xmlWriter, children.at(i));
         }
-        // QString str = tempDoc.toString();
-        // str.remove(QRegularExpression("[\\n\\t\\r]+"));
-        // str.replace(QRegularExpression(">\\s+<"), "><");
-        // xmlWriter.writeCharacters("");
-        // xmlWriter.device()->write(str.toUtf8());
     } else {
-        // String/Number 
+        // String/Number
         xmlWriter.writeCharacters(xmlString);
     }
 }


### PR DESCRIPTION
Raw xml formatting is prone to a few errors (like #105, #100) that we can basically totally avoid if we format the inline xml via Qt's xml stream writer. This does that.

Closes #105.