### PR TITLE
Fix spectrum partial row spacing

### DIFF
--- a/LASSIE/src/widgets/EventAttributesViewController.cpp
+++ b/LASSIE/src/widgets/EventAttributesViewController.cpp
@@ -19,6 +19,7 @@
 
 #include <functional>
 
+
 using enum FunctionReturnType;
 
 // EventAttributesViewController::EventAttributesViewController(SharedPointers* sharedPointers,
@@ -187,8 +188,14 @@ void EventAttributesViewController::fixStackedWidgetLayout(QWidget* currPage) {
     currPage->adjustSize();
 
     if (currPage == ui->soundPage && ui->soundPage->layout()) {
-        ui->soundPage->layout()->setSpacing(10);
-        ui->partialsLayout->setSpacing(0);
+        //// Issue #40: keep spectrum partial rows tightly packed.
+        //// ui->soundPage->layout()->setSpacing(10);
+        //// ui->partialsLayout->setSpacing(0);
+
+        ui->soundPage->layout()->setSpacing(0);
+        ui->partialsLayout->setContentsMargins(0, 0, 0, 0);
+        ui->partialsLayout->setAlignment(Qt::AlignTop);
+        ////
     }
     if (currPage == ui->standardPage && ui->standardPage->layout()) {
         ui->standardPage->layout()->setSpacing(10);
@@ -1205,6 +1212,7 @@ void EventAttributesViewController::addNewLayerButtonClicked() {
 }
 
 void EventAttributesViewController::addPartialsUI(int partialIndex) {
+
     Partials* par = new Partials(m_curreventindex, partialIndex, this);
     connect(par, &Partials::deleteRequested, this, [this](Partials* p) {
         qDebug() << "deleting in addPartialsUI";

--- a/LASSIE/src/widgets/EventAttributesViewController.cpp
+++ b/LASSIE/src/widgets/EventAttributesViewController.cpp
@@ -19,7 +19,6 @@
 
 #include <functional>
 
-
 using enum FunctionReturnType;
 
 // EventAttributesViewController::EventAttributesViewController(SharedPointers* sharedPointers,
@@ -188,14 +187,12 @@ void EventAttributesViewController::fixStackedWidgetLayout(QWidget* currPage) {
     currPage->adjustSize();
 
     if (currPage == ui->soundPage && ui->soundPage->layout()) {
-        //// Issue #40: keep spectrum partial rows tightly packed.
-        //// ui->soundPage->layout()->setSpacing(10);
-        //// ui->partialsLayout->setSpacing(0);
+        // Set spacing between spectrum partial rows.
 
         ui->soundPage->layout()->setSpacing(0);
         ui->partialsLayout->setContentsMargins(0, 0, 0, 0);
         ui->partialsLayout->setAlignment(Qt::AlignTop);
-        ////
+
     }
     if (currPage == ui->standardPage && ui->standardPage->layout()) {
         ui->standardPage->layout()->setSpacing(10);
@@ -1212,7 +1209,6 @@ void EventAttributesViewController::addNewLayerButtonClicked() {
 }
 
 void EventAttributesViewController::addPartialsUI(int partialIndex) {
-
     Partials* par = new Partials(m_curreventindex, partialIndex, this);
     connect(par, &Partials::deleteRequested, this, [this](Partials* p) {
         qDebug() << "deleting in addPartialsUI";

--- a/LASSIE/src/widgets/EventAttributesViewController.cpp
+++ b/LASSIE/src/widgets/EventAttributesViewController.cpp
@@ -188,11 +188,9 @@ void EventAttributesViewController::fixStackedWidgetLayout(QWidget* currPage) {
 
     if (currPage == ui->soundPage && ui->soundPage->layout()) {
         // Set spacing between spectrum partial rows.
-
         ui->soundPage->layout()->setSpacing(0);
         ui->partialsLayout->setContentsMargins(0, 0, 0, 0);
         ui->partialsLayout->setAlignment(Qt::AlignTop);
-
     }
     if (currPage == ui->standardPage && ui->standardPage->layout()) {
         ui->standardPage->layout()->setSpacing(10);

--- a/LASSIE/src/widgets/Partials.cpp
+++ b/LASSIE/src/widgets/Partials.cpp
@@ -8,7 +8,6 @@ Partials::Partials(unsigned eventIndex, int partialIndex, QWidget* parent)
       m_eventIndex(eventIndex),
       m_partialIndex(partialIndex)
 {
-
     m_mainLayout = new QVBoxLayout(this);
     m_mainLayout->setContentsMargins(0, 0, 0, 0);
     m_mainLayout->setSpacing(0);
@@ -29,12 +28,11 @@ Partials::Partials(unsigned eventIndex, int partialIndex, QWidget* parent)
             [this](FunctionEntryRow*){ emit deleteRequested(this); });
     connect(m_row, &FunctionEntryRow::textChanged, this,
             [this](FunctionEntryRow*){ getBackendLayer().partials[m_partialIndex] = m_row->getText(); });
-           
+
     m_mainLayout->addWidget(m_row);
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
-    //// Issue #40
+    // Set spacing between spectrum partial rows.
     setFixedHeight(28);
-    ////
 }
 
 

--- a/LASSIE/src/widgets/Partials.cpp
+++ b/LASSIE/src/widgets/Partials.cpp
@@ -8,6 +8,7 @@ Partials::Partials(unsigned eventIndex, int partialIndex, QWidget* parent)
       m_eventIndex(eventIndex),
       m_partialIndex(partialIndex)
 {
+
     m_mainLayout = new QVBoxLayout(this);
     m_mainLayout->setContentsMargins(0, 0, 0, 0);
     m_mainLayout->setSpacing(0);
@@ -28,9 +29,12 @@ Partials::Partials(unsigned eventIndex, int partialIndex, QWidget* parent)
             [this](FunctionEntryRow*){ emit deleteRequested(this); });
     connect(m_row, &FunctionEntryRow::textChanged, this,
             [this](FunctionEntryRow*){ getBackendLayer().partials[m_partialIndex] = m_row->getText(); });
-
+           
     m_mainLayout->addWidget(m_row);
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    //// Issue #40
+    setFixedHeight(28);
+    ////
 }
 
 

--- a/LASSIE/src/widgets/generic/FunctionEntryRow.cpp
+++ b/LASSIE/src/widgets/generic/FunctionEntryRow.cpp
@@ -16,10 +16,10 @@ FunctionEntryRow::FunctionEntryRow(const QString& labelText,
 
     m_hBox    = new QHBoxLayout(this);
 
-    //// Issue #40   
+    //// Set spacing between spectrum partial rows
     m_hBox->setContentsMargins(0, 0, 0, 0);
     m_hBox->setSpacing(4);
-    ////
+
     
     m_label   = new QLabel(labelText);
     m_entry   = new QLineEdit;
@@ -39,9 +39,7 @@ FunctionEntryRow::FunctionEntryRow(const QString& labelText,
     connect(m_entry,    &QLineEdit::textChanged,         this, &FunctionEntryRow::onTextChanged);
     connect(m_entry,    &QLineEdit::cursorPositionChanged, this, [this](){ emit editFocused(m_entry); });
 
-    //// Issue #40
-    //// m_entry->setFixedHeight(20);
-    //// setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    // Set spacing between spectrum partial rows
     m_label->setFixedHeight(24);
     m_entry->setFixedHeight(24);
 
@@ -51,7 +49,7 @@ FunctionEntryRow::FunctionEntryRow(const QString& labelText,
 
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     setFixedHeight(28);
-    ////   
+
 }
 
 QString FunctionEntryRow::getText() const {

--- a/LASSIE/src/widgets/generic/FunctionEntryRow.cpp
+++ b/LASSIE/src/widgets/generic/FunctionEntryRow.cpp
@@ -15,6 +15,12 @@ FunctionEntryRow::FunctionEntryRow(const QString& labelText,
     setFrameShape(QFrame::NoFrame);
 
     m_hBox    = new QHBoxLayout(this);
+
+    //// Issue #40   
+    m_hBox->setContentsMargins(0, 0, 0, 0);
+    m_hBox->setSpacing(4);
+    ////
+    
     m_label   = new QLabel(labelText);
     m_entry   = new QLineEdit;
     if(fnVisible) { m_fnButton = new QPushButton("fn"); }
@@ -33,8 +39,19 @@ FunctionEntryRow::FunctionEntryRow(const QString& labelText,
     connect(m_entry,    &QLineEdit::textChanged,         this, &FunctionEntryRow::onTextChanged);
     connect(m_entry,    &QLineEdit::cursorPositionChanged, this, [this](){ emit editFocused(m_entry); });
 
-    m_entry->setFixedHeight(20);
+    //// Issue #40
+    //// m_entry->setFixedHeight(20);
+    //// setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    m_label->setFixedHeight(24);
+    m_entry->setFixedHeight(24);
+
+    if (fnVisible) { m_fnButton->setFixedHeight(24); }
+    if (rmVisible) { m_rmButton->setFixedHeight(24); }
+    if (insVisible) { m_insButton->setFixedHeight(24); }
+
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    setFixedHeight(28);
+    ////   
 }
 
 QString FunctionEntryRow::getText() const {

--- a/LASSIE/src/widgets/generic/FunctionEntryRow.cpp
+++ b/LASSIE/src/widgets/generic/FunctionEntryRow.cpp
@@ -15,12 +15,10 @@ FunctionEntryRow::FunctionEntryRow(const QString& labelText,
     setFrameShape(QFrame::NoFrame);
 
     m_hBox    = new QHBoxLayout(this);
-
-    //// Set spacing between spectrum partial rows
+    // Set spacing between spectrum partial rows
     m_hBox->setContentsMargins(0, 0, 0, 0);
     m_hBox->setSpacing(4);
 
-    
     m_label   = new QLabel(labelText);
     m_entry   = new QLineEdit;
     if(fnVisible) { m_fnButton = new QPushButton("fn"); }
@@ -38,18 +36,15 @@ FunctionEntryRow::FunctionEntryRow(const QString& labelText,
     if(insVisible) { connect(m_insButton, &QPushButton::clicked, this, &FunctionEntryRow::onInsClicked); }
     connect(m_entry,    &QLineEdit::textChanged,         this, &FunctionEntryRow::onTextChanged);
     connect(m_entry,    &QLineEdit::cursorPositionChanged, this, [this](){ emit editFocused(m_entry); });
-
     // Set spacing between spectrum partial rows
     m_label->setFixedHeight(24);
     m_entry->setFixedHeight(24);
-
     if (fnVisible) { m_fnButton->setFixedHeight(24); }
     if (rmVisible) { m_rmButton->setFixedHeight(24); }
     if (insVisible) { m_insButton->setFixedHeight(24); }
 
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     setFixedHeight(28);
-
 }
 
 QString FunctionEntryRow::getText() const {


### PR DESCRIPTION
This PR addresses issue #40, where Spectrum partial rows in the Qt LASSIE interface were spaced too far apart compared with the previous DISSCO 2.1 layout.

I updated the relevant row and layout settings so that partials remain closely packed together. I also tested adding and removing multiple partials locally on macOS after rebuilding LASSIE.

Closes #40