### PR TITLE
Fix SignalHandlers.h build on Windows

### DIFF
--- a/CMOD/src/SignalHandlers.h
+++ b/CMOD/src/SignalHandlers.h
@@ -1,4 +1,3 @@
-
 /**
  * @file SignalHandlers.h
  * @brief Custom POSIX signal handlers for CMOD (Rubin Du, 2024).
@@ -17,61 +16,68 @@
 
 #include <iostream>
 #include <csignal>
-#include <execinfo.h>
 #include <cstdlib>
-#include <unistd.h>
-#include <cxxabi.h>
 #include <algorithm>
 #include <cstring>
+#include <cstddef>
 
 #ifdef _WIN32
-  #include <io.h>
 
-  #ifndef STDERR_FILENO
-    #define STDERR_FILENO 2
-  #endif
+#include <io.h>
 
-  inline int backtrace(void** buffer, int size) {
-    return 0;
-  }
-
-  inline char** backtrace_symbols(void* const* buffer, int size) {
-    return nullptr;
-  }
-
-  inline void backtrace_symbols_fd(void* const* buffer, int size, int fd) {
-  }
-
-  namespace abi {
-    inline char* __cxa_demangle(const char* mangled_name,
-                                char* output_buffer,
-                                size_t* length,
-                                int* status) {
-      if (status) {
-        *status = -1;
-      }
-      return nullptr;
-    }
-  }
-#else
-  #include <execinfo.h>
-  #include <unistd.h>
-  #include <cxxabi.h>
+#ifndef STDERR_FILENO
+#define STDERR_FILENO 2
 #endif
 
-#define BACKTRACE_NUM 10    // Number of stack frames to print
+// Windows does not provide POSIX backtrace functions.
+// These stubs preserve compilation while disabling stack traces.
+inline int backtrace(void**, int) {
+  return 0;
+}
+
+inline char** backtrace_symbols(void* const*, int) {
+  return nullptr;
+}
+
+inline void backtrace_symbols_fd(void* const*, int, int) {
+}
+
+namespace abi {
+
+inline char* __cxa_demangle(const char*,
+                           char*,
+                           std::size_t*,
+                           int* status) {
+  if (status != nullptr) {
+    *status = -1;
+  }
+
+  return nullptr;
+}
+
+}  // namespace abi
+
+#else
+
+#include <execinfo.h>
+#include <unistd.h>
+#include <cxxabi.h>
+
+#endif
+
+#define BACKTRACE_NUM 10
 
 // Rubin Du 2024
-// Custom signal handler to print stack trace on segfault and then exit
+// Custom signal handler to print stack trace on segfault and then exit.
 void segfaultHandler(int signal);
 
-// Unimplemented, can be used to detect ctrl+c while the output is generating and decide whether to abandon and clean up the output or not, and release resources
+// Can be used to detect Ctrl+C during output generation.
 void interruptHandler(int signal);
 
-// Unimplemented, could be the same as the above but for quitting unexpectedly
+// Can be used for unexpected termination handling.
 void terminateHandler();
 
-//Unimplemented, could be useful in conjunction with assert to detect trash inputs or other unexpected behavior
+// Can be used with assert or invalid-input handling.
 void abortHandler();
 
 #endif


### PR DESCRIPTION
- Move POSIX-only headers behind the non-Windows conditional
- Keep Windows-compatible stubs for backtrace functions
- Fix MSVC build failure caused by missing `execinfo.h`