### PR TITLE
Add partial modifier dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     find_program(LLD_LINKER ld.lld)
     if(LLD_LINKER)
         add_link_options(-fuse-ld=lld)
-        message(STATUS "Using lld linker")
-        
+        message(STATUS "Using lld linker")       
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     if(LLD_LINKER)
         add_link_options(-fuse-ld=lld)
         message(STATUS "Using lld linker")
+        
     endif()
 endif()
 

--- a/LASSIE/CMakeLists.txt
+++ b/LASSIE/CMakeLists.txt
@@ -19,6 +19,7 @@ qt_add_executable(LASSIE
     src/widgets/EnvLibDrawingArea.cpp src/widgets/EnvLibDrawingArea.hpp 
     src/core/EnvelopeLibraryEntry.cpp src/core/EnvelopeLibraryEntry.hpp
     src/dialogs/FunctionGenerator.cpp src/dialogs/FunctionGenerator.hpp src/ui/FunctionGenerator.ui
+    src/dialogs/PartialModifierDialog.cpp src/dialogs/PartialModifierDialog.hpp
     src/dialogs/functions/FunctionWidget.cpp src/dialogs/functions/FunctionWidget.hpp
     src/dialogs/functions/FunctionRegistry.cpp src/dialogs/functions/FunctionRegistry.hpp
     src/dialogs/functions/MultiEntryFunction.cpp src/dialogs/functions/MultiEntryFunction.hpp

--- a/LASSIE/src/dialogs/PartialModifierDialog.cpp
+++ b/LASSIE/src/dialogs/PartialModifierDialog.cpp
@@ -5,16 +5,13 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QMessageBox>
-
 #include <QLineEdit>
 #include <QStringList>
 #include "FunctionGenerator.hpp"
 #include <QRegularExpression>
+#include <QPlainTextEdit>
 
 using enum FunctionReturnType;
-
-
-
 
 PartialModifierDialog::PartialModifierDialog(
     int modifierType,
@@ -26,14 +23,22 @@ PartialModifierDialog::PartialModifierDialog(
       m_modifierType(modifierType),
       m_maxPartialCount(maxPartialCount)
 {
-    setWindowTitle("Partial Modifier");
-    resize(700, 400);
+    setWindowTitle("Customize Partials");
+    resize(950, 500);
 
     m_mainLayout = new QVBoxLayout(this);
     m_rowsLayout = new QVBoxLayout();
 
     m_mainLayout->addLayout(m_rowsLayout);
     m_mainLayout->addStretch();
+
+    QLabel* resultLabel = new QLabel("Result String", this);
+    m_resultPreview = new QPlainTextEdit(this);
+    m_resultPreview->setReadOnly(true);
+    m_resultPreview->setMinimumHeight(55);
+
+    m_mainLayout->addWidget(resultLabel);
+    m_mainLayout->addWidget(m_resultPreview);
 
     QHBoxLayout* buttonLayout = new QHBoxLayout();
 
@@ -66,6 +71,7 @@ PartialModifierDialog::PartialModifierDialog(
             this, &QDialog::reject);
 
     populateFromResultString(existingResultString);
+    updateResultPreview();
 }
 
 
@@ -91,49 +97,96 @@ void PartialModifierDialog::addNode()
 
     ++m_nodeCount;
 
-    QHBoxLayout* rowLayout = new QHBoxLayout();
+    QWidget* rowContainer = new QWidget(this);
+    QHBoxLayout* rowLayout = new QHBoxLayout(rowContainer);
+    rowLayout->setContentsMargins(0, 0, 0, 0);
 
     QLabel* partialLabel = new QLabel(
-        "Partial " + QString::number(m_nodeCount) + ":", this);
+        "Partial #" + QString::number(m_nodeCount), this);
     rowLayout->addWidget(partialLabel);
 
-    const QStringList fields = enabledFieldLabels();
-
     PartialRow row;
+    row.container = rowContainer;
+    row.partialLabel = partialLabel;
 
-    for (const QString& fieldLabel : fields) {
-        QLabel* label = new QLabel(fieldLabel, this);
-        QLineEdit* edit = new QLineEdit(this);
+    const EnvelopeEnabled enabled = enabledEnvelopeFields();
 
-        edit->setMinimumWidth(120);
+    row.probabilityLabel = new QLabel("Probability:", this);
+    row.probability = new QLineEdit(this);
+    row.probability->setText(enabled.probability ? "PROB" : "");
+    row.probability->setMinimumWidth(120);
 
-        connect(edit, &QLineEdit::cursorPositionChanged,
-                this, [this, edit]() {
-                    trackFocusedEdit(edit);
-                });
+    row.magnitudeLabel = new QLabel("Magnitude:", this);
+    row.magnitude = new QLineEdit(this);
+    row.magnitude->setText(enabled.magnitude ? "AMP" : "");
+    row.magnitude->setMinimumWidth(120);
 
-        if (fieldLabel == "Probability Envelope:") {
-            row.probability = edit;
-        } else if (fieldLabel == "Magnitude Envelope:") {
-            row.magnitude = edit;
-        } else if (fieldLabel == "Rate Value Envelope:") {
-            row.rate = edit;
-        } else if (fieldLabel == "Width Envelope:") {
-            row.width = edit;
-        } else if (fieldLabel == "Detune Spread:") {
-            row.spread = edit;
-        } else if (fieldLabel == "Detune Direction:") {
-            row.direction = edit;
-        } else if (fieldLabel == "Detune Velocity:") {
-            row.velocity = edit;
-        }
+    row.widthLabel = new QLabel("Width:", this);
+    row.width = new QLineEdit(this);
+    row.width->setText(enabled.width ? "WIDTH" : "");
+    row.width->setMinimumWidth(120);
 
-        rowLayout->addWidget(label);
-        rowLayout->addWidget(edit);
-    }
+    row.rateLabel = new QLabel("Rate Value:", this);
+    row.rate = new QLineEdit(this);
+    row.rate->setText(enabled.rate ? "RATE" : "");
+    row.rate->setMinimumWidth(120);
+
+    connect(row.probability, &QLineEdit::cursorPositionChanged,
+            this, [this, row]() {
+                trackFocusedEdit(row.probability);
+            });
+
+    connect(row.magnitude, &QLineEdit::cursorPositionChanged,
+            this, [this, row]() {
+                trackFocusedEdit(row.magnitude);
+            });
+
+    connect(row.width, &QLineEdit::cursorPositionChanged,
+            this, [this, row]() {
+                trackFocusedEdit(row.width);
+            });
+
+    connect(row.rate, &QLineEdit::cursorPositionChanged,
+            this, [this, row]() {
+                trackFocusedEdit(row.rate);
+            });
+    connect(row.probability, &QLineEdit::textChanged,
+        this, &PartialModifierDialog::updateResultPreview);
+
+    connect(row.magnitude, &QLineEdit::textChanged,
+            this, &PartialModifierDialog::updateResultPreview);
+
+    connect(row.width, &QLineEdit::textChanged,
+            this, &PartialModifierDialog::updateResultPreview);
+
+    connect(row.rate, &QLineEdit::textChanged,
+            this, &PartialModifierDialog::updateResultPreview);
+    
+    rowLayout->addWidget(row.probabilityLabel);
+    rowLayout->addWidget(row.probability);
+
+    rowLayout->addWidget(row.magnitudeLabel);
+    rowLayout->addWidget(row.magnitude);
+
+    rowLayout->addWidget(row.widthLabel);
+    rowLayout->addWidget(row.width);
+
+    rowLayout->addWidget(row.rateLabel);
+    rowLayout->addWidget(row.rate);
+
+    QPushButton* removeButton = new QPushButton("Remove Node", this);
+    connect(removeButton, &QPushButton::clicked,
+        this, [this, rowContainer]() {
+            removeNode(rowContainer);
+        });
+
+    rowLayout->addWidget(removeButton);
+
+    applyRowEnabledState(row);
 
     m_rows.append(row);
-    m_rowsLayout->addLayout(rowLayout);
+    m_rowsLayout->addWidget(rowContainer);
+    updateResultPreview();
 }
 
 
@@ -208,18 +261,18 @@ void PartialModifierDialog::trackFocusedEdit(QLineEdit* edit)
 
 QString PartialModifierDialog::envelopeOrNA(QLineEdit* edit)
 {
-    if (!edit || edit->text().trimmed().isEmpty()) {
-        return "N/A";
+    if (!edit) {
+        return "";
     }
+
     return edit->text();
 }
+
 QString PartialModifierDialog::buildPartialResultString() const
 {
-    QString result = "<Fun><Name>PartialResult</Name><Envelopes>";
+    QString result = "<Fun><Name>Partials</Name><Envelopes>";
 
     for (const PartialRow& row : m_rows) {
-        // CMOD currently reads four envelopes per partial in this fixed order:
-        // probability, magnitude/amplitude, width, rate.
         result += "<Envelope>" + envelopeOrNA(row.probability) + "</Envelope>";
         result += "<Envelope>" + envelopeOrNA(row.magnitude) + "</Envelope>";
         result += "<Envelope>" + envelopeOrNA(row.width) + "</Envelope>";
@@ -278,24 +331,152 @@ void PartialModifierDialog::populateFromResultString(const QString& resultString
         const QString width       = envelopes[i * valuesPerPartial + 2];
         const QString rate        = envelopes[i * valuesPerPartial + 3];
 
-        if (row.probability && probability != "N/A") {
+        if (row.probability) {
             row.probability->setText(probability);
         }
 
-        if (row.magnitude && magnitude != "N/A") {
+        if (row.magnitude) {
             row.magnitude->setText(magnitude);
         }
 
-        if (row.width && width != "N/A") {
+        if (row.width) {
             row.width->setText(width);
         }
 
-        if (row.rate && rate != "N/A") {
+        if (row.rate) {
             row.rate->setText(rate);
+        }
+
+        applyRowEnabledState(row);
+    }
+}
+
+PartialModifierDialog::EnvelopeEnabled PartialModifierDialog::enabledEnvelopeFields() const
+{
+    EnvelopeEnabled enabled;
+
+    switch (m_modifierType) {
+        case 0: // TREMOLO
+            enabled.probability = true;
+            enabled.magnitude = true;
+            enabled.width = false;
+            enabled.rate = true;
+            break;
+
+        case 1: // VIBRATO
+            enabled.probability = true;
+            enabled.magnitude = true;
+            enabled.width = false;
+            enabled.rate = true;
+            break;
+
+        case 2: // GLISSANDO
+            enabled.probability = true;
+            enabled.magnitude = true;
+            enabled.width = false;
+            enabled.rate = false;
+            break;
+
+        case 4: // AMPTRANS
+            enabled.probability = true;
+            enabled.magnitude = true;
+            enabled.width = true;
+            enabled.rate = true;
+            break;
+
+        case 5: // FREQTRANS
+            enabled.probability = true;
+            enabled.magnitude = true;
+            enabled.width = true;
+            enabled.rate = true;
+            break;
+
+        case 6: // WAVE_TYPE
+            enabled.probability = true;
+            enabled.magnitude = true;
+            enabled.width = false;
+            enabled.rate = true;
+            break;
+
+        default:
+            enabled.probability = true;
+            enabled.magnitude = true;
+            enabled.width = true;
+            enabled.rate = true;
+            break;
+    }
+
+    return enabled;
+}
+
+void PartialModifierDialog::applyRowEnabledState(const PartialRow& row) const
+{
+    const EnvelopeEnabled enabled = enabledEnvelopeFields();
+
+    auto apply = [](QLabel* label, QLineEdit* edit, bool isEnabled) {
+        if (label) {
+            label->setEnabled(isEnabled);
+        }
+
+        if (edit) {
+            edit->setEnabled(isEnabled);
+
+            if (!isEnabled) {
+                edit->clear();
+            }
+        }
+    };
+
+    apply(row.probabilityLabel, row.probability, enabled.probability);
+    apply(row.magnitudeLabel, row.magnitude, enabled.magnitude);
+    apply(row.widthLabel, row.width, enabled.width);
+    apply(row.rateLabel, row.rate, enabled.rate);
+}
+
+void PartialModifierDialog::removeNode(QWidget* rowContainer)
+{
+    if (!rowContainer) {
+        return;
+    }
+
+    for (int i = 0; i < m_rows.size(); ++i) {
+        if (m_rows[i].container == rowContainer) {
+            m_rows.removeAt(i);
+            break;
+        }
+    }
+
+    if (m_lastFocusedEdit && rowContainer->isAncestorOf(m_lastFocusedEdit)) {
+        m_lastFocusedEdit = nullptr;
+    }
+
+    m_rowsLayout->removeWidget(rowContainer);
+    rowContainer->deleteLater();
+
+    m_nodeCount = m_rows.size();
+    renumberRows();
+    updateResultPreview();
+}
+
+void PartialModifierDialog::renumberRows()
+{
+    for (int i = 0; i < m_rows.size(); ++i) {
+        if (m_rows[i].partialLabel) {
+            m_rows[i].partialLabel->setText(
+                "Partial #" + QString::number(i + 1)
+            );
         }
     }
 }
 
+void PartialModifierDialog::updateResultPreview()
+{
+    if (!m_resultPreview) {
+        return;
+    }
+
+    m_resultPreview->setPlainText(buildPartialResultString());
+}
 
 QString PartialModifierDialog::getResultString() const
 {

--- a/LASSIE/src/dialogs/PartialModifierDialog.cpp
+++ b/LASSIE/src/dialogs/PartialModifierDialog.cpp
@@ -1,0 +1,304 @@
+#include "PartialModifierDialog.hpp"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QLabel>
+#include <QMessageBox>
+
+#include <QLineEdit>
+#include <QStringList>
+#include "FunctionGenerator.hpp"
+#include <QRegularExpression>
+
+using enum FunctionReturnType;
+
+
+
+
+PartialModifierDialog::PartialModifierDialog(
+    int modifierType,
+    int maxPartialCount,
+    const QString& existingResultString,
+    QWidget* parent
+)
+    : QDialog(parent),
+      m_modifierType(modifierType),
+      m_maxPartialCount(maxPartialCount)
+{
+    setWindowTitle("Partial Modifier");
+    resize(700, 400);
+
+    m_mainLayout = new QVBoxLayout(this);
+    m_rowsLayout = new QVBoxLayout();
+
+    m_mainLayout->addLayout(m_rowsLayout);
+    m_mainLayout->addStretch();
+
+    QHBoxLayout* buttonLayout = new QHBoxLayout();
+
+    m_addNodeButton = new QPushButton("Add Node", this);
+    m_insertFunctionButton = new QPushButton("Insert Function", this);
+    m_okButton = new QPushButton("OK", this);
+    m_cancelButton = new QPushButton("Cancel", this);
+
+    buttonLayout->addStretch();
+    buttonLayout->addWidget(m_addNodeButton);
+    buttonLayout->addSpacing(20);
+    buttonLayout->addWidget(m_insertFunctionButton);
+    buttonLayout->addSpacing(20);
+    buttonLayout->addWidget(m_okButton);
+    buttonLayout->addWidget(m_cancelButton);
+    buttonLayout->addStretch();
+
+    m_mainLayout->addLayout(buttonLayout);
+
+    connect(m_addNodeButton, &QPushButton::clicked,
+            this, &PartialModifierDialog::addNode);
+
+    connect(m_insertFunctionButton, &QPushButton::clicked,
+            this, &PartialModifierDialog::insertFunction);
+
+    connect(m_okButton, &QPushButton::clicked,
+            this, &QDialog::accept);
+
+    connect(m_cancelButton, &QPushButton::clicked,
+            this, &QDialog::reject);
+
+    populateFromResultString(existingResultString);
+}
+
+
+void PartialModifierDialog::addNode()
+{
+    if (m_maxPartialCount <= 0) {
+        QMessageBox::warning(
+            this,
+            "No Spectrum",
+            "This Bottom event does not contain a Spectrum, so partial nodes cannot be added."
+        );
+        return;
+    }
+
+    if (m_nodeCount >= m_maxPartialCount) {
+        QMessageBox::warning(
+            this,
+            "Partial Limit Reached",
+            "Cannot add more partial nodes than the maximum number of partials in this Bottom event's spectra."
+        );
+        return;
+    }
+
+    ++m_nodeCount;
+
+    QHBoxLayout* rowLayout = new QHBoxLayout();
+
+    QLabel* partialLabel = new QLabel(
+        "Partial " + QString::number(m_nodeCount) + ":", this);
+    rowLayout->addWidget(partialLabel);
+
+    const QStringList fields = enabledFieldLabels();
+
+    PartialRow row;
+
+    for (const QString& fieldLabel : fields) {
+        QLabel* label = new QLabel(fieldLabel, this);
+        QLineEdit* edit = new QLineEdit(this);
+
+        edit->setMinimumWidth(120);
+
+        connect(edit, &QLineEdit::cursorPositionChanged,
+                this, [this, edit]() {
+                    trackFocusedEdit(edit);
+                });
+
+        if (fieldLabel == "Probability Envelope:") {
+            row.probability = edit;
+        } else if (fieldLabel == "Magnitude Envelope:") {
+            row.magnitude = edit;
+        } else if (fieldLabel == "Rate Value Envelope:") {
+            row.rate = edit;
+        } else if (fieldLabel == "Width Envelope:") {
+            row.width = edit;
+        } else if (fieldLabel == "Detune Spread:") {
+            row.spread = edit;
+        } else if (fieldLabel == "Detune Direction:") {
+            row.direction = edit;
+        } else if (fieldLabel == "Detune Velocity:") {
+            row.velocity = edit;
+        }
+
+        rowLayout->addWidget(label);
+        rowLayout->addWidget(edit);
+    }
+
+    m_rows.append(row);
+    m_rowsLayout->addLayout(rowLayout);
+}
+
+
+void PartialModifierDialog::insertFunction()
+{
+    if (!m_lastFocusedEdit) {
+        QMessageBox::warning(this,
+                             "No Field Selected",
+                             "Please select a field before inserting a function.");
+        return;
+    }
+
+    FunctionGenerator* gen = new FunctionGenerator(
+        this,
+        functionReturnENV,
+        m_lastFocusedEdit->text()
+    );
+
+    if (gen) {
+        if (gen->exec() == QDialog::Accepted && !gen->getResultString().isEmpty()) {
+            m_lastFocusedEdit->setText(gen->getResultString());
+        }
+        delete gen;
+    }
+}
+
+QStringList PartialModifierDialog::enabledFieldLabels() const
+{
+    // Field order:
+    // Probability, Magnitude, Rate, Width, Detune Spread, Detune Direction, Detune Velocity
+    static const bool table[7][7] = {
+        /* TREMOLO   */ { true,  true,  true,  false, false, false, false },
+        /* VIBRATO   */ { true,  true,  true,  false, false, false, false },
+        /* GLISSANDO */ { true,  true,  false, false, false, false, false },
+        /* DETUNE    */ { true,  false, false, false, true,  true,  true  },
+        /* AMPTRANS  */ { true,  true,  true,  true,  false, false, false },
+        /* FREQTRANS */ { true,  true,  true,  true,  false, false, false },
+        /* WAVE_TYPE */ { true,  true,  true,  false, false, false, false },
+    };
+
+    const QString labels[7] = {
+        "Probability Envelope:",
+        "Magnitude Envelope:",
+        "Rate Value Envelope:",
+        "Width Envelope:",
+        "Detune Spread:",
+        "Detune Direction:",
+        "Detune Velocity:"
+    };
+
+    QStringList result;
+
+    if (m_modifierType < 0 || m_modifierType >= 7) {
+        return result;
+    }
+
+    for (int i = 0; i < 7; ++i) {
+        if (table[m_modifierType][i]) {
+            result.append(labels[i]);
+        }
+    }
+
+    return result;
+}
+
+void PartialModifierDialog::trackFocusedEdit(QLineEdit* edit)
+{
+    m_lastFocusedEdit = edit;
+}
+
+
+
+QString PartialModifierDialog::envelopeOrNA(QLineEdit* edit)
+{
+    if (!edit || edit->text().trimmed().isEmpty()) {
+        return "N/A";
+    }
+    return edit->text();
+}
+QString PartialModifierDialog::buildPartialResultString() const
+{
+    QString result = "<Fun><Name>PartialResult</Name><Envelopes>";
+
+    for (const PartialRow& row : m_rows) {
+        // CMOD currently reads four envelopes per partial in this fixed order:
+        // probability, magnitude/amplitude, width, rate.
+        result += "<Envelope>" + envelopeOrNA(row.probability) + "</Envelope>";
+        result += "<Envelope>" + envelopeOrNA(row.magnitude) + "</Envelope>";
+        result += "<Envelope>" + envelopeOrNA(row.width) + "</Envelope>";
+        result += "<Envelope>" + envelopeOrNA(row.rate) + "</Envelope>";
+    }
+
+    result += "</Envelopes></Fun>";
+    return result;
+}
+
+QStringList PartialModifierDialog::extractEnvelopeValues(const QString& resultString)
+{
+    QStringList values;
+
+    QRegularExpression re("<Envelope>([\\s\\S]*?)</Envelope>");
+    QRegularExpressionMatchIterator it = re.globalMatch(resultString);
+
+    while (it.hasNext()) {
+        QRegularExpressionMatch match = it.next();
+        values.append(match.captured(1));
+    }
+
+    return values;
+}
+
+void PartialModifierDialog::populateFromResultString(const QString& resultString)
+{
+    if (resultString.trimmed().isEmpty()) {
+        return;
+    }
+
+    const QStringList envelopes = extractEnvelopeValues(resultString);
+
+    if (envelopes.isEmpty()) {
+        return;
+    }
+
+    // CMOD currently reads 4 envelopes per partial:
+    // probability, magnitude, width, rate
+    const int valuesPerPartial = 4;
+    const int partialCount = envelopes.size() / valuesPerPartial;
+
+    for (int i = 0; i < partialCount; ++i) {
+        const int oldRowCount = m_rows.size();
+
+        addNode();
+
+        if (m_rows.size() == oldRowCount) {
+            return;
+        }
+
+        PartialRow& row = m_rows.last();
+
+        const QString probability = envelopes[i * valuesPerPartial + 0];
+        const QString magnitude   = envelopes[i * valuesPerPartial + 1];
+        const QString width       = envelopes[i * valuesPerPartial + 2];
+        const QString rate        = envelopes[i * valuesPerPartial + 3];
+
+        if (row.probability && probability != "N/A") {
+            row.probability->setText(probability);
+        }
+
+        if (row.magnitude && magnitude != "N/A") {
+            row.magnitude->setText(magnitude);
+        }
+
+        if (row.width && width != "N/A") {
+            row.width->setText(width);
+        }
+
+        if (row.rate && rate != "N/A") {
+            row.rate->setText(rate);
+        }
+    }
+}
+
+
+QString PartialModifierDialog::getResultString() const
+{
+    return buildPartialResultString();
+}
+

--- a/LASSIE/src/dialogs/PartialModifierDialog.hpp
+++ b/LASSIE/src/dialogs/PartialModifierDialog.hpp
@@ -1,0 +1,66 @@
+#ifndef PARTIALMODIFIERDIALOG_HPP
+#define PARTIALMODIFIERDIALOG_HPP
+
+#include <QDialog>
+#include "../dialogs/FunctionGenerator.hpp"
+#include <QString>
+#include <QVector>
+
+class QVBoxLayout;
+class QPushButton;
+class QLineEdit;
+
+
+class PartialModifierDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit PartialModifierDialog(
+    int modifierType,
+    int maxPartialCount,
+    const QString& existingResultString = QString(),
+    QWidget* parent = nullptr
+);
+    QString getResultString() const;
+
+private:
+    struct PartialRow {
+        QLineEdit* probability = nullptr;
+        QLineEdit* magnitude = nullptr;
+        QLineEdit* width = nullptr;
+        QLineEdit* rate = nullptr;
+        QLineEdit* spread = nullptr;
+        QLineEdit* direction = nullptr;
+        QLineEdit* velocity = nullptr;
+    };
+
+    QVector<PartialRow> m_rows;
+
+    QString buildPartialResultString() const;
+    static QString envelopeOrNA(QLineEdit* edit);
+
+
+    QVBoxLayout* m_mainLayout = nullptr;
+    QVBoxLayout* m_rowsLayout = nullptr;
+    QPushButton* m_addNodeButton = nullptr;
+    QPushButton* m_insertFunctionButton = nullptr;
+    QLineEdit* m_lastFocusedEdit = nullptr;
+    QPushButton* m_okButton = nullptr;
+    QPushButton* m_cancelButton = nullptr;
+
+    int m_nodeCount = 0;
+    int m_modifierType = 0;
+    int m_maxPartialCount = 0;
+
+    QStringList enabledFieldLabels() const;
+    void trackFocusedEdit(QLineEdit* edit);
+    void populateFromResultString(const QString& resultString);
+    static QStringList extractEnvelopeValues(const QString& resultString);
+
+private slots:
+    void addNode();
+    void insertFunction();
+};
+
+#endif // PARTIALMODIFIERDIALOG_HPP

--- a/LASSIE/src/dialogs/PartialModifierDialog.hpp
+++ b/LASSIE/src/dialogs/PartialModifierDialog.hpp
@@ -9,7 +9,9 @@
 class QVBoxLayout;
 class QPushButton;
 class QLineEdit;
-
+class QLabel;
+class QWidget;
+class QPlainTextEdit;
 
 class PartialModifierDialog : public QDialog
 {
@@ -26,16 +28,34 @@ public:
 
 private:
     struct PartialRow {
+        QWidget* container = nullptr;
+        QLabel* partialLabel = nullptr;
+
+        QLabel* probabilityLabel = nullptr;
+        QLabel* magnitudeLabel = nullptr;
+        QLabel* widthLabel = nullptr;
+        QLabel* rateLabel = nullptr;
+
         QLineEdit* probability = nullptr;
         QLineEdit* magnitude = nullptr;
         QLineEdit* width = nullptr;
         QLineEdit* rate = nullptr;
-        QLineEdit* spread = nullptr;
-        QLineEdit* direction = nullptr;
-        QLineEdit* velocity = nullptr;
     };
 
+    struct EnvelopeEnabled {
+        bool probability = true;
+        bool magnitude = true;
+        bool width = true;
+        bool rate = true;
+    };    
+
     QVector<PartialRow> m_rows;
+
+    EnvelopeEnabled enabledEnvelopeFields() const;
+    void applyRowEnabledState(const PartialRow& row) const;
+
+    void removeNode(QWidget* rowContainer);
+    void renumberRows();
 
     QString buildPartialResultString() const;
     static QString envelopeOrNA(QLineEdit* edit);
@@ -49,6 +69,8 @@ private:
     QPushButton* m_okButton = nullptr;
     QPushButton* m_cancelButton = nullptr;
 
+    QPlainTextEdit* m_resultPreview = nullptr;
+
     int m_nodeCount = 0;
     int m_modifierType = 0;
     int m_maxPartialCount = 0;
@@ -57,6 +79,7 @@ private:
     void trackFocusedEdit(QLineEdit* edit);
     void populateFromResultString(const QString& resultString);
     static QStringList extractEnvelopeValues(const QString& resultString);
+    void updateResultPreview();
 
 private slots:
     void addNode();

--- a/LASSIE/src/widgets/EventAttributesViewController.cpp
+++ b/LASSIE/src/widgets/EventAttributesViewController.cpp
@@ -19,7 +19,6 @@
 
 #include <functional>
 
-
 using enum FunctionReturnType;
 
 // EventAttributesViewController::EventAttributesViewController(SharedPointers* sharedPointers,
@@ -188,14 +187,10 @@ void EventAttributesViewController::fixStackedWidgetLayout(QWidget* currPage) {
     currPage->adjustSize();
 
     if (currPage == ui->soundPage && ui->soundPage->layout()) {
-        //// Issue #40: keep spectrum partial rows tightly packed.
-        //// ui->soundPage->layout()->setSpacing(10);
-        //// ui->partialsLayout->setSpacing(0);
-
+        // Set spacing between spectrum partial rows.
         ui->soundPage->layout()->setSpacing(0);
         ui->partialsLayout->setContentsMargins(0, 0, 0, 0);
         ui->partialsLayout->setAlignment(Qt::AlignTop);
-        ////
     }
     if (currPage == ui->standardPage && ui->standardPage->layout()) {
         ui->standardPage->layout()->setSpacing(10);
@@ -460,19 +455,12 @@ void EventAttributesViewController::saveCurrentShownEventData() {
             event.filter = ui->filEntry->text();
         }
 
-        // // save modifiers
-        // for (Modifiers* mod : m_modifiers) {
-        //     mod->saveModifierToBackend();
-        // }
-
-        // ISSUE#123:
         // Modifiers are only editable for Bottom events.
         if (type == bottom) {
             for (Modifiers* mod : m_modifiers) {
                 mod->saveModifierToBackend();
             }
         }
-        ////
 
         // save layer weights
         for (LayerBox* box : m_layerBoxes) {
@@ -580,7 +568,6 @@ void EventAttributesViewController::showCurrentEventData() {
         case bottom: {
             ui->stackedWidget->setCurrentWidget(ui->standardPage);
 
-            // ISSUE#123
             const bool showBottomOnlyControls = (type == bottom);
 
             ui->frequencyContainer->setVisible(showBottomOnlyControls);
@@ -589,7 +576,7 @@ void EventAttributesViewController::showCurrentEventData() {
 
             ui->addModifierButton->setVisible(showBottomOnlyControls);
             ui->modifiersLabel->setVisible(showBottomOnlyControls);
-            ////
+
             fixStackedWidgetLayout(ui->standardPage);
             break;
         }
@@ -638,7 +625,6 @@ void EventAttributesViewController::showCurrentEventData() {
     // ui->nameEntry->setText(QString::fromStdString(m_currentlyShownEvent->getEventName()));
     HEvent event;
     if(type <= bottom){
-    //// ISSUE#123:
     // Clear existing modifier widgets whenever switching standard-page events.
     // Modifiers should only be shown for Bottom events.
     for (Modifiers* mod : m_modifiers) {
@@ -646,7 +632,7 @@ void EventAttributesViewController::showCurrentEventData() {
         mod->deleteLater();
     }
     m_modifiers.clear();
-    ////
+
         if(type == bottom){
             const BottomEvent& bottom_event = pm->bottomevents()[m_curreventindex];
             ExtraInfo extra_info = bottom_event.extra_info;
@@ -760,26 +746,6 @@ void EventAttributesViewController::showCurrentEventData() {
         ui->durationTypePercentRadio->setChecked(dt_flag == 0);
         ui->durationTypeUnitsRadio->setChecked(dt_flag == 1);
         ui->durationTypeSecondsRadio->setChecked(dt_flag == 2);
-
-        // ISSUE#123: DELETE //
-        //// clear and rebuild hevent modifier widgets
-        //if (type != bottom) {
-            //// clear existing Modifiers widgets
-            //for (Modifiers* mod : m_modifiers) {
-                //ui->modifiersLayout->removeWidget(mod);
-                //mod->deleteLater();
-            //}
-            //m_modifiers.clear();
-
-            ///// rebuild Modifiers
-            //for (int i = 0; i < event.modifiers.size(); ++i) {
-                //addModifiersUI(i);
-                //m_modifiers[i]->setModifierData(event.modifiers[i]);
-            //}
- 
-        //}
-        /////
-
 
         // environment
         if (type != bottom) {
@@ -1307,7 +1273,6 @@ void EventAttributesViewController::addModifiersUI(int modifierIndex) {
     
 }
 
-// ISSUE#123:
 void EventAttributesViewController::addModifierButtonClicked() {
     qDebug("add new modifier button clicked");
 
@@ -1321,7 +1286,6 @@ void EventAttributesViewController::addModifierButtonClicked() {
     bevent->modifiers.append(Modifier());
     addModifiersUI(bevent->modifiers.size() - 1);
 }
-////
 
 void EventAttributesViewController::tempoAsNoteValueButtonClicked() {
     ui->tempoSecondaryStack->setCurrentWidget(ui->tempoValuePage);

--- a/LASSIE/src/widgets/EventAttributesViewController.cpp
+++ b/LASSIE/src/widgets/EventAttributesViewController.cpp
@@ -460,10 +460,19 @@ void EventAttributesViewController::saveCurrentShownEventData() {
             event.filter = ui->filEntry->text();
         }
 
-        // save modifiers
-        for (Modifiers* mod : m_modifiers) {
-            mod->saveModifierToBackend();
+        // // save modifiers
+        // for (Modifiers* mod : m_modifiers) {
+        //     mod->saveModifierToBackend();
+        // }
+
+        // ISSUE#123:
+        // Modifiers are only editable for Bottom events.
+        if (type == bottom) {
+            for (Modifiers* mod : m_modifiers) {
+                mod->saveModifierToBackend();
+            }
         }
+        ////
 
         // save layer weights
         for (LayerBox* box : m_layerBoxes) {
@@ -568,19 +577,22 @@ void EventAttributesViewController::showCurrentEventData() {
         case high: 
         case mid: 
         case low: 
-        case bottom:
+        case bottom: {
             ui->stackedWidget->setCurrentWidget(ui->standardPage);
-            if (type == bottom) {  
-                ui->frequencyContainer->setVisible(true);
-                ui->loudnessContainer->setVisible(true);
-                ui->modGroupContainer->setVisible(true);
-            } else {
-                ui->frequencyContainer->setVisible(false);
-                ui->loudnessContainer->setVisible(false);
-                ui->modGroupContainer->setVisible(false);
-            }
+
+            // ISSUE#123
+            const bool showBottomOnlyControls = (type == bottom);
+
+            ui->frequencyContainer->setVisible(showBottomOnlyControls);
+            ui->loudnessContainer->setVisible(showBottomOnlyControls);
+            ui->modGroupContainer->setVisible(showBottomOnlyControls);
+
+            ui->addModifierButton->setVisible(showBottomOnlyControls);
+            ui->modifiersLabel->setVisible(showBottomOnlyControls);
+            ////
             fixStackedWidgetLayout(ui->standardPage);
             break;
+        }
         case sound:
             ui->stackedWidget->setCurrentWidget(ui->soundPage);
             break;
@@ -626,6 +638,15 @@ void EventAttributesViewController::showCurrentEventData() {
     // ui->nameEntry->setText(QString::fromStdString(m_currentlyShownEvent->getEventName()));
     HEvent event;
     if(type <= bottom){
+    //// ISSUE#123:
+    // Clear existing modifier widgets whenever switching standard-page events.
+    // Modifiers should only be shown for Bottom events.
+    for (Modifiers* mod : m_modifiers) {
+        ui->modifiersLayout->removeWidget(mod);
+        mod->deleteLater();
+    }
+    m_modifiers.clear();
+    ////
         if(type == bottom){
             const BottomEvent& bottom_event = pm->bottomevents()[m_curreventindex];
             ExtraInfo extra_info = bottom_event.extra_info;
@@ -650,12 +671,6 @@ void EventAttributesViewController::showCurrentEventData() {
             ui->filEntry->setText(extra_info.filter);
             ui->modifierGroupEntry->setText(extra_info.modifier_group);
 
-            // clear existing Modifiers widgets
-            for (Modifiers* mod : m_modifiers) {
-                ui->modifiersLayout->removeWidget(mod);
-                mod->deleteLater();
-            }
-            m_modifiers.clear();
 
             // rebuild buttom Modifiers
             for (int i = 0; i < extra_info.modifiers.size(); ++i) {
@@ -746,22 +761,26 @@ void EventAttributesViewController::showCurrentEventData() {
         ui->durationTypeUnitsRadio->setChecked(dt_flag == 1);
         ui->durationTypeSecondsRadio->setChecked(dt_flag == 2);
 
-        // clear and rebuild hevent modifier widgets
-        if (type != bottom) {
-            // clear existing Modifiers widgets
-            for (Modifiers* mod : m_modifiers) {
-                ui->modifiersLayout->removeWidget(mod);
-                mod->deleteLater();
-            }
-            m_modifiers.clear();
+        // ISSUE#123: DELETE //
+        //// clear and rebuild hevent modifier widgets
+        //if (type != bottom) {
+            //// clear existing Modifiers widgets
+            //for (Modifiers* mod : m_modifiers) {
+                //ui->modifiersLayout->removeWidget(mod);
+                //mod->deleteLater();
+            //}
+            //m_modifiers.clear();
 
-            // rebuild Modifiers
-            for (int i = 0; i < event.modifiers.size(); ++i) {
-                addModifiersUI(i);
-                m_modifiers[i]->setModifierData(event.modifiers[i]);
-            }
+            ///// rebuild Modifiers
+            //for (int i = 0; i < event.modifiers.size(); ++i) {
+                //addModifiersUI(i);
+                //m_modifiers[i]->setModifierData(event.modifiers[i]);
+            //}
  
-        }
+        //}
+        /////
+
+
         // environment
         if (type != bottom) {
             ui->spaEntry->setText(event.spa);
@@ -1288,25 +1307,21 @@ void EventAttributesViewController::addModifiersUI(int modifierIndex) {
     
 }
 
+// ISSUE#123:
 void EventAttributesViewController::addModifierButtonClicked() {
     qDebug("add new modifier button clicked");
 
-    ProjectManager *pm = Inst::get_project_manager();
-
     if (m_curreventtype != bottom) {
-        HEvent* hevent = nullptr;
-        if (m_curreventtype == top)         hevent = &pm->topevent();
-        else if (m_curreventtype == high)   hevent = &pm->highevents()[m_curreventindex];
-        else if (m_curreventtype == mid)    hevent = &pm->midevents()[m_curreventindex];
-        else if (m_curreventtype == low)    hevent = &pm->lowevents()[m_curreventindex];
-        hevent->modifiers.append(Modifier());
-        addModifiersUI(hevent->modifiers.size() - 1);
-    } else {
-        ExtraInfo* bevent = &pm->bottomevents()[m_curreventindex].extra_info;
-        bevent->modifiers.append(Modifier());
-        addModifiersUI(bevent->modifiers.size() - 1);
+        return;
     }
+
+    ProjectManager *pm = Inst::get_project_manager();
+    ExtraInfo* bevent = &pm->bottomevents()[m_curreventindex].extra_info;
+
+    bevent->modifiers.append(Modifier());
+    addModifiersUI(bevent->modifiers.size() - 1);
 }
+////
 
 void EventAttributesViewController::tempoAsNoteValueButtonClicked() {
     ui->tempoSecondaryStack->setCurrentWidget(ui->tempoValuePage);

--- a/LASSIE/src/widgets/Modifiers.cpp
+++ b/LASSIE/src/widgets/Modifiers.cpp
@@ -10,7 +10,7 @@
 #include <QTextEdit>
 #include <QDialogButtonBox>
 #include <QDialog>
-
+#include <QSizePolicy>
 #include <string>
 
 #include "../ui/ui_Attributes.h"
@@ -28,8 +28,8 @@ Modifiers::Modifiers(Eventtype eventType, unsigned eventIndex, int modifierIndex
       m_modifierIndex(modifierIndex)
 {
     ui->setupUi(this);
-    this->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
-    this->setMinimumHeight(480);
+    this->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
+    this->setMinimumHeight(0);
 
     setupUi();
     ui->modifierSpreadLabel->adjustSize();
@@ -195,6 +195,36 @@ void Modifiers::setupUi() {
                 updateFieldsForApplyMode();
                 updateModState();
             });
+    //set spacing
+    ui->modifierGroupLayout->setContentsMargins(0, 0, 0, 0);
+    ui->modifierGroupLayout->setSpacing(0);
+
+    ui->modifierLayout->setContentsMargins(8, 8, 8, 8);
+    ui->modifierLayout->setSpacing(4);
+
+    ui->modifierRemoveLayout->setContentsMargins(0, 0, 0, 0);
+    ui->modifierRemoveLayout->setSpacing(6);
+
+    ui->modifierNameLayout->setContentsMargins(0, 0, 0, 0);
+    ui->modifierNameLayout->setSpacing(6);
+
+    ui->modifierProbLayout->setContentsMargins(0, 0, 0, 0);
+    ui->modifierProbLayout->setSpacing(6);
+
+    ui->modifierMagLayout->setContentsMargins(0, 0, 0, 0);
+    ui->modifierMagLayout->setSpacing(6);
+
+    ui->modifierRateLayout->setContentsMargins(0, 0, 0, 0);
+    ui->modifierRateLayout->setSpacing(6);
+
+    ui->modifierWidthLayout->setContentsMargins(0, 0, 0, 0);
+    ui->modifierWidthLayout->setSpacing(6);
+
+    ui->modifierDetuneLayout->setContentsMargins(0, 0, 0, 0);
+    ui->modifierDetuneLayout->setSpacing(6);
+
+    ui->modifierResLayout->setContentsMargins(0, 0, 0, 0);
+    ui->modifierResLayout->setSpacing(6);
 }
 
 
@@ -342,7 +372,7 @@ void Modifiers::updateModState() {
     }
     enabled[7] = false;
     }
-    ////
+
     for (int i = 0; i < 8; i++) {
         rows[i].label->setEnabled(enabled[i]);
         rows[i].edit->setEnabled(enabled[i]);
@@ -357,9 +387,11 @@ void Modifiers::updateModState() {
 void Modifiers::updateApplyOptionsForModifierType()
 {
     const int typeIndex = ui->modifierType->currentIndex();
-
-    // DETUNE is index 3 in the modifier type combo.
     const bool isDetune = (typeIndex == 3);
+
+    Modifier& mod = getBackendLayer();
+
+    const bool shouldUsePartial = (!isDetune && mod.applyhow_flag);
 
     ui->modifierApply->blockSignals(true);
 
@@ -370,12 +402,8 @@ void Modifiers::updateApplyOptionsForModifierType()
         ui->modifierApply->addItem("PARTIAL");
     }
 
-    if (isDetune) {
-        ui->modifierApply->setCurrentIndex(0);
-        getBackendLayer().applyhow_flag = false;
-    } else {
-        getBackendLayer().applyhow_flag = (ui->modifierApply->currentIndex() == 1);
-    }
+    ui->modifierApply->setCurrentIndex(shouldUsePartial ? 1 : 0);
+    mod.applyhow_flag = shouldUsePartial;
 
     ui->modifierApply->blockSignals(false);
 }
@@ -453,7 +481,7 @@ void Modifiers::modFunctionButtonClicked(ModChanged type) {
     }
 
     if (!target) return;
-////
+
     if (type == modPartialChanged
         && ui->modifierApply->currentIndex() == 1
         && ui->modifierType->currentIndex() != 3) {
@@ -476,7 +504,7 @@ void Modifiers::modFunctionButtonClicked(ModChanged type) {
 
         return;
     }
-////
+
     gen = new FunctionGenerator(nullptr, functionReturnENV, target->text());
     if (gen) {
         if (gen->exec() == QDialog::Accepted && !gen->getResultString().isEmpty())
@@ -485,13 +513,11 @@ void Modifiers::modFunctionButtonClicked(ModChanged type) {
     }
 }
 
-
-// ISSUE#123:
 void Modifiers::saveModifierToBackend() {
     Modifier& mod = getBackendLayer();
 
     mod.type = ui->modifierType->currentIndex();
-    mod.applyhow_flag = ui->modifierApply->currentIndex();
+    mod.applyhow_flag = (ui->modifierApply->currentIndex() == 1);
 
     modTextChanged(modNameChanged);
 
@@ -580,5 +606,3 @@ Modifiers::~Modifiers()
 {
     delete ui;
 }
-
-

--- a/LASSIE/src/widgets/Modifiers.cpp
+++ b/LASSIE/src/widgets/Modifiers.cpp
@@ -11,6 +11,7 @@
 #include <QDialogButtonBox>
 #include <QDialog>
 #include <QSizePolicy>
+
 #include <string>
 
 #include "../ui/ui_Attributes.h"
@@ -43,7 +44,6 @@ Modifiers::Modifiers(Eventtype eventType, unsigned eventIndex, int modifierIndex
     setModifierData(modData);
 }
 
-////
 int Modifiers::maxPartialCountForCurrentBottom() const
 {
     if (m_eventType != bottom) {
@@ -80,7 +80,6 @@ int Modifiers::maxPartialCountForCurrentBottom() const
 
     return maxCount;
 }
-////
 
 Modifier& Modifiers::getBackendLayer() {
     ProjectManager* pm = Inst::get_project_manager();
@@ -305,8 +304,6 @@ void Modifiers::updateFieldsForApplyMode() {
     ui->modifierResEdit->setText(isPartial ? mod.partialresult_string : "");
     ui->modifierResEdit->blockSignals(false);
 }
-////
-
 
 void Modifiers::updateModState() {
     int typeIndex = ui->modifierType->currentIndex();
@@ -350,15 +347,7 @@ void Modifiers::updateModState() {
     };
 
     bool enabled[8];
-    // ISSUE#123:
-    // for (int i = 0; i < 7; i++) enabled[i] = table[typeIndex][i];
-    // enabled[7] = isPartial;
 
-    // for (int i = 0; i < 8; i++) {
-    //     rows[i].label->setEnabled(enabled[i]);
-    //     rows[i].edit->setEnabled(enabled[i]);
-    //     rows[i].btn->setEnabled(enabled[i]);
-    // }
     if (isPartial) {
     // In PARTIAL mode, only Group Name and Partial Result String are editable.
     for (int i = 0; i < 7; i++) {
@@ -537,7 +526,6 @@ void Modifiers::saveModifierToBackend() {
         modTextChanged(modVelChanged);
     }
 }
-////
 
 void Modifiers::setModifierData(Modifier& modData) {
     ui->modifierType->blockSignals(true);
@@ -598,8 +586,6 @@ void Modifiers::setModifierData(Modifier& modData) {
 
     updateFieldsForApplyMode();
     updateModState();
-
-
 }
 
 Modifiers::~Modifiers()

--- a/LASSIE/src/widgets/Modifiers.cpp
+++ b/LASSIE/src/widgets/Modifiers.cpp
@@ -16,6 +16,7 @@
 #include "../ui/ui_Attributes.h"
 #include "../inst.hpp"
 #include "../dialogs/FunctionGenerator.hpp"
+#include "../dialogs/PartialModifierDialog.hpp"
 
 using enum FunctionReturnType;
 
@@ -41,6 +42,45 @@ Modifiers::Modifiers(Eventtype eventType, unsigned eventIndex, int modifierIndex
     Modifier& modData = getBackendLayer();
     setModifierData(modData);
 }
+
+////
+int Modifiers::maxPartialCountForCurrentBottom() const
+{
+    if (m_eventType != bottom) {
+        return 0;
+    }
+
+    ProjectManager* pm = Inst::get_project_manager();
+    if (!pm || m_eventIndex >= static_cast<unsigned>(pm->bottomevents().size())) {
+        return 0;
+    }
+
+    const HEvent& bottomEvent = pm->bottomevents()[m_eventIndex].event;
+    const QList<SpectrumEvent>& spectra = pm->spectrumevents();
+
+    int maxCount = 0;
+
+    for (const Layer& layer : bottomEvent.event_layers) {
+        for (const Package& package : layer.discrete_packages) {
+            bool ok = false;
+            const int packageType = package.event_type.toInt(&ok);
+
+            if (!ok || packageType != sound) {
+                continue;
+            }
+
+            for (const SpectrumEvent& spectrumEvent : spectra) {
+                if (spectrumEvent.name == package.event_name) {
+                    maxCount = qMax(maxCount, spectrumEvent.spectrum.partials.size());
+                    break;
+                }
+            }
+        }
+    }
+
+    return maxCount;
+}
+////
 
 Modifier& Modifiers::getBackendLayer() {
     ProjectManager* pm = Inst::get_project_manager();
@@ -144,14 +184,99 @@ void Modifiers::setupUi() {
     connect(ui->modifierType, QOverload<int>::of(&QComboBox::currentIndexChanged),
             this, [this](int index) {
                 getBackendLayer().type = index;
+                updateApplyOptionsForModifierType();
+
+                updateFieldsForApplyMode();
                 updateModState();
             });
     connect(ui->modifierApply, QOverload<int>::of(&QComboBox::currentIndexChanged),
             this, [this](int index) {
-                getBackendLayer().applyhow_flag = index;
+                getBackendLayer().applyhow_flag = (index == 1);
+                updateFieldsForApplyMode();
                 updateModState();
             });
 }
+
+
+// 3 Helper Functions
+void Modifiers::setSoundFieldsFromBackend() {
+    Modifier& mod = getBackendLayer();
+
+    ui->modifierProbEdit->blockSignals(true);
+    ui->modifierProbEdit->setText(mod.probability);
+    ui->modifierProbEdit->blockSignals(false);
+
+    ui->modifierMagEdit->blockSignals(true);
+    ui->modifierMagEdit->setText(mod.amplitude);
+    ui->modifierMagEdit->blockSignals(false);
+
+    ui->modifierRateEdit->blockSignals(true);
+    ui->modifierRateEdit->setText(mod.rate);
+    ui->modifierRateEdit->blockSignals(false);
+
+    ui->modifierWidthEdit->blockSignals(true);
+    ui->modifierWidthEdit->setText(mod.width);
+    ui->modifierWidthEdit->blockSignals(false);
+
+    ui->modifierSpreadEdit->blockSignals(true);
+    ui->modifierSpreadEdit->setText(mod.detune_spread);
+    ui->modifierSpreadEdit->blockSignals(false);
+
+    ui->modifierDirEdit->blockSignals(true);
+    ui->modifierDirEdit->setText(mod.detune_direction);
+    ui->modifierDirEdit->blockSignals(false);
+
+    ui->modifierVelEdit->blockSignals(true);
+    ui->modifierVelEdit->setText(mod.detune_velocity);
+    ui->modifierVelEdit->blockSignals(false);
+}
+
+void Modifiers::clearSoundFieldsForPartialMode() {
+    ui->modifierProbEdit->blockSignals(true);
+    ui->modifierProbEdit->clear();
+    ui->modifierProbEdit->blockSignals(false);
+
+    ui->modifierMagEdit->blockSignals(true);
+    ui->modifierMagEdit->clear();
+    ui->modifierMagEdit->blockSignals(false);
+
+    ui->modifierRateEdit->blockSignals(true);
+    ui->modifierRateEdit->clear();
+    ui->modifierRateEdit->blockSignals(false);
+
+    ui->modifierWidthEdit->blockSignals(true);
+    ui->modifierWidthEdit->clear();
+    ui->modifierWidthEdit->blockSignals(false);
+
+    ui->modifierSpreadEdit->blockSignals(true);
+    ui->modifierSpreadEdit->clear();
+    ui->modifierSpreadEdit->blockSignals(false);
+
+    ui->modifierDirEdit->blockSignals(true);
+    ui->modifierDirEdit->clear();
+    ui->modifierDirEdit->blockSignals(false);
+
+    ui->modifierVelEdit->blockSignals(true);
+    ui->modifierVelEdit->clear();
+    ui->modifierVelEdit->blockSignals(false);
+}
+
+void Modifiers::updateFieldsForApplyMode() {
+    const bool isPartial = (ui->modifierApply->currentIndex() == 1);
+
+    if (isPartial) {
+        clearSoundFieldsForPartialMode();
+    } else {
+        setSoundFieldsFromBackend();
+    }
+
+    Modifier& mod = getBackendLayer();
+    ui->modifierResEdit->blockSignals(true);
+    ui->modifierResEdit->setText(isPartial ? mod.partialresult_string : "");
+    ui->modifierResEdit->blockSignals(false);
+}
+////
+
 
 void Modifiers::updateModState() {
     int typeIndex = ui->modifierType->currentIndex();
@@ -195,14 +320,64 @@ void Modifiers::updateModState() {
     };
 
     bool enabled[8];
-    for (int i = 0; i < 7; i++) enabled[i] = table[typeIndex][i];
-    enabled[7] = isPartial;
+    // ISSUE#123:
+    // for (int i = 0; i < 7; i++) enabled[i] = table[typeIndex][i];
+    // enabled[7] = isPartial;
 
+    // for (int i = 0; i < 8; i++) {
+    //     rows[i].label->setEnabled(enabled[i]);
+    //     rows[i].edit->setEnabled(enabled[i]);
+    //     rows[i].btn->setEnabled(enabled[i]);
+    // }
+    if (isPartial) {
+    // In PARTIAL mode, only Group Name and Partial Result String are editable.
+    for (int i = 0; i < 7; i++) {
+        enabled[i] = false;
+    }
+    enabled[7] = true;
+    } else {
+    // In SOUND mode, field availability depends on the modifier type.
+    for (int i = 0; i < 7; i++) {
+        enabled[i] = table[typeIndex][i];
+    }
+    enabled[7] = false;
+    }
+    ////
     for (int i = 0; i < 8; i++) {
         rows[i].label->setEnabled(enabled[i]);
         rows[i].edit->setEnabled(enabled[i]);
         rows[i].btn->setEnabled(enabled[i]);
     }
+
+    ui->modifierNameLabel->setEnabled(true);
+    ui->modifierNameEdit->setEnabled(true);
+}
+
+
+void Modifiers::updateApplyOptionsForModifierType()
+{
+    const int typeIndex = ui->modifierType->currentIndex();
+
+    // DETUNE is index 3 in the modifier type combo.
+    const bool isDetune = (typeIndex == 3);
+
+    ui->modifierApply->blockSignals(true);
+
+    ui->modifierApply->clear();
+    ui->modifierApply->addItem("SOUND");
+
+    if (!isDetune) {
+        ui->modifierApply->addItem("PARTIAL");
+    }
+
+    if (isDetune) {
+        ui->modifierApply->setCurrentIndex(0);
+        getBackendLayer().applyhow_flag = false;
+    } else {
+        getBackendLayer().applyhow_flag = (ui->modifierApply->currentIndex() == 1);
+    }
+
+    ui->modifierApply->blockSignals(false);
 }
 
 void Modifiers::modTextChanged(ModChanged type) {
@@ -278,7 +453,30 @@ void Modifiers::modFunctionButtonClicked(ModChanged type) {
     }
 
     if (!target) return;
+////
+    if (type == modPartialChanged
+        && ui->modifierApply->currentIndex() == 1
+        && ui->modifierType->currentIndex() != 3) {
 
+        const int maxPartialCount = maxPartialCountForCurrentBottom();
+
+        PartialModifierDialog dialog(
+            ui->modifierType->currentIndex(),
+            maxPartialCount,
+            target->text(),
+            this
+        );
+
+        if (dialog.exec() == QDialog::Accepted) {
+            const QString result = dialog.getResultString();
+            if (!result.isEmpty()) {
+                target->setText(result);
+            }
+        }
+
+        return;
+    }
+////
     gen = new FunctionGenerator(nullptr, functionReturnENV, target->text());
     if (gen) {
         if (gen->exec() == QDialog::Accepted && !gen->getResultString().isEmpty())
@@ -287,28 +485,53 @@ void Modifiers::modFunctionButtonClicked(ModChanged type) {
     }
 }
 
-void Modifiers::saveModifierToBackend() {
-    getBackendLayer().type = ui->modifierType->currentIndex();
-    getBackendLayer().applyhow_flag = ui->modifierApply->currentIndex();
-    modTextChanged(modNameChanged);
-    modTextChanged(modProbabilityChanged);
-    modTextChanged(modMagnitudeChanged);
-    modTextChanged(modRateChanged);
-    modTextChanged(modWidthChanged);
-    modTextChanged(modPartialChanged);
-    modTextChanged(modSpreadChanged);
-    modTextChanged(modDirChanged);
-    modTextChanged(modVelChanged);
 
+// ISSUE#123:
+void Modifiers::saveModifierToBackend() {
+    Modifier& mod = getBackendLayer();
+
+    mod.type = ui->modifierType->currentIndex();
+    mod.applyhow_flag = ui->modifierApply->currentIndex();
+
+    modTextChanged(modNameChanged);
+
+    if (mod.applyhow_flag == 1) {
+        // PARTIAL mode: sound-related fields are visually cleared and disabled,
+        // so only save the partial result string.
+        modTextChanged(modPartialChanged);
+    } else {
+        // SOUND mode: partial result string is hidden/disabled,
+        // so only save sound-related fields.
+        modTextChanged(modProbabilityChanged);
+        modTextChanged(modMagnitudeChanged);
+        modTextChanged(modRateChanged);
+        modTextChanged(modWidthChanged);
+        modTextChanged(modSpreadChanged);
+        modTextChanged(modDirChanged);
+        modTextChanged(modVelChanged);
+    }
 }
+////
 
 void Modifiers::setModifierData(Modifier& modData) {
     ui->modifierType->blockSignals(true);
     ui->modifierType->setCurrentIndex(modData.type);
     ui->modifierType->blockSignals(false);
 
+    // Rebuild Apply options after setting modifier type.
+    // DETUNE should only have SOUND.
+    updateApplyOptionsForModifierType();
+
     ui->modifierApply->blockSignals(true);
-    ui->modifierApply->setCurrentIndex(modData.applyhow_flag);
+
+    if (ui->modifierType->currentIndex() == 3) {
+        // DETUNE does not support PARTIAL mode.
+        ui->modifierApply->setCurrentIndex(0);
+        modData.applyhow_flag = false;
+    } else {
+        ui->modifierApply->setCurrentIndex(modData.applyhow_flag ? 1 : 0);
+    }
+
     ui->modifierApply->blockSignals(false);
 
     ui->modifierProbEdit->blockSignals(true);
@@ -347,7 +570,10 @@ void Modifiers::setModifierData(Modifier& modData) {
     ui->modifierResEdit->setText(modData.partialresult_string);
     ui->modifierResEdit->blockSignals(false);
 
+    updateFieldsForApplyMode();
     updateModState();
+
+
 }
 
 Modifiers::~Modifiers()

--- a/LASSIE/src/widgets/Modifiers.hpp
+++ b/LASSIE/src/widgets/Modifiers.hpp
@@ -53,6 +53,14 @@ private:
     void setupUi();
     void updateModState();
 
+
+    void updateFieldsForApplyMode();
+    void setSoundFieldsFromBackend();
+    void clearSoundFieldsForPartialMode();
+    void updateApplyOptionsForModifierType();
+
+    int maxPartialCountForCurrentBottom() const;
+    
     Modifier& getBackendLayer();
 
     Eventtype m_eventType;

--- a/LASSIE/src/widgets/Partials.cpp
+++ b/LASSIE/src/widgets/Partials.cpp
@@ -8,7 +8,6 @@ Partials::Partials(unsigned eventIndex, int partialIndex, QWidget* parent)
       m_eventIndex(eventIndex),
       m_partialIndex(partialIndex)
 {
-
     m_mainLayout = new QVBoxLayout(this);
     m_mainLayout->setContentsMargins(0, 0, 0, 0);
     m_mainLayout->setSpacing(0);
@@ -32,9 +31,8 @@ Partials::Partials(unsigned eventIndex, int partialIndex, QWidget* parent)
            
     m_mainLayout->addWidget(m_row);
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
-    //// Issue #40
+    // Set spacing between spectrum partial rows.
     setFixedHeight(28);
-    ////
 }
 
 

--- a/LASSIE/src/widgets/generic/FunctionEntryRow.cpp
+++ b/LASSIE/src/widgets/generic/FunctionEntryRow.cpp
@@ -15,11 +15,9 @@ FunctionEntryRow::FunctionEntryRow(const QString& labelText,
     setFrameShape(QFrame::NoFrame);
 
     m_hBox    = new QHBoxLayout(this);
-
-    //// Issue #40   
+    // Set spacing between spectrum partial rows
     m_hBox->setContentsMargins(0, 0, 0, 0);
     m_hBox->setSpacing(4);
-    ////
     
     m_label   = new QLabel(labelText);
     m_entry   = new QLineEdit;
@@ -38,20 +36,15 @@ FunctionEntryRow::FunctionEntryRow(const QString& labelText,
     if(insVisible) { connect(m_insButton, &QPushButton::clicked, this, &FunctionEntryRow::onInsClicked); }
     connect(m_entry,    &QLineEdit::textChanged,         this, &FunctionEntryRow::onTextChanged);
     connect(m_entry,    &QLineEdit::cursorPositionChanged, this, [this](){ emit editFocused(m_entry); });
-
-    //// Issue #40
-    //// m_entry->setFixedHeight(20);
-    //// setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    // Set spacing between spectrum partial rows
     m_label->setFixedHeight(24);
     m_entry->setFixedHeight(24);
-
     if (fnVisible) { m_fnButton->setFixedHeight(24); }
     if (rmVisible) { m_rmButton->setFixedHeight(24); }
     if (insVisible) { m_insButton->setFixedHeight(24); }
 
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     setFixedHeight(28);
-    ////   
 }
 
 QString FunctionEntryRow::getText() const {


### PR DESCRIPTION
This PR adds a new Partial Modifier dialog for editing partial-mode modifier result strings.

Changes include:
- Open a custom Partial Modifier dialog when editing Partial Result String in PARTIAL mode.
- Disable PARTIAL mode for DETUNE modifiers.
- Add partial nodes based on the current Bottom event's Spectrum partial count.
- Display Probability, Magnitude, Width, and Rate fields for each partial node.
- Disable unsupported fields depending on the selected modifier type.
- Add default values for enabled fields:
  - Probability: PROB
  - Magnitude: AMP
  - Width: WIDTH
  - Rate Value: RATE
- Support inserting Function Generator results into individual partial fields.
- Generate and preview the Partial Result String XML.
- Restore existing partial rows from the saved XML when reopening the dialog.
- Support removing partial nodes.
- Tighten modifier row spacing in the main modifier UI.

Closed#123