### PR TITLE
Func size of entry

### DIFF
--- a/LASSIE/src/dialogs/functions/MultiEntryFunction.cpp
+++ b/LASSIE/src/dialogs/functions/MultiEntryFunction.cpp
@@ -9,7 +9,9 @@ MultiEntryFunction::MultiEntryFunction(QList<EntrySpec> specs, QWidget* parent)
       m_specs(std::move(specs))
 {
     auto* layout = new QVBoxLayout(this);
-
+    layout->setSpacing(1);                    // vertical gap between rows
+    layout->setContentsMargins(0, 0, 0, 0);  // padding around all rows
+    layout->setAlignment(Qt::AlignTop);
     int idx = 0;
     for (const EntrySpec& s : m_specs) {
         auto* row = new FunctionEntryRow(s.labelText, idx++, s.fnReturnType,

--- a/LASSIE/src/dialogs/functions/impl/MakeEnvelopeFunction.cpp
+++ b/LASSIE/src/dialogs/functions/impl/MakeEnvelopeFunction.cpp
@@ -86,7 +86,7 @@ void MakeEnvelopeFunction::clearRows() {
 
 void MakeEnvelopeFunction::updateRowLabels() {
     for (int i = 0; i < m_rows.size(); ++i)
-        m_rows[i]->setLabel(QStringLiteral("Point %1:").arg(i + 1));
+        m_rows[i]->setLabel(QStringLiteral("Node %1:").arg(i + 1));
 }
 
 QString MakeEnvelopeFunction::buildXMLString() const {

--- a/LASSIE/src/dialogs/functions/impl/MakeEnvelopeFunction.cpp
+++ b/LASSIE/src/dialogs/functions/impl/MakeEnvelopeFunction.cpp
@@ -32,7 +32,7 @@ MakeEnvelopeFunction::MakeEnvelopeFunction(QWidget* parent)
     layout->addWidget(m_scrollArea);
 
     auto* addRow = new QHBoxLayout;
-    auto* addButton = new QPushButton(tr("Add Point"), this);
+    auto* addButton = new QPushButton(tr("Add Node"), this);
     addRow->addWidget(addButton);
     addRow->addStretch(1);
     layout->addLayout(addRow);

--- a/LASSIE/src/dialogs/functions/impl/MakeSieveFunction.cpp
+++ b/LASSIE/src/dialogs/functions/impl/MakeSieveFunction.cpp
@@ -30,7 +30,9 @@ MakeSieveFunction::MakeSieveFunction(QWidget* parent)
     : FunctionWidget(parent)
 {
     auto* layout = new QVBoxLayout(this);
-
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(2);
+    layout->setAlignment(Qt::AlignTop);
     // Low/High bounds. Legacy uses ENV-returning dialogs here (matching).
     m_lowRow  = new FunctionEntryRow(tr("Low Bound:"),  0,
                                      FunctionReturnType::functionReturnENV,

--- a/LASSIE/src/dialogs/functions/impl/SelectFunction.cpp
+++ b/LASSIE/src/dialogs/functions/impl/SelectFunction.cpp
@@ -30,6 +30,9 @@ SelectFunction::SelectFunction(QWidget* parent)
     m_scrollArea->setMinimumSize(400, 200);
     auto* scrollContents = new QWidget;
     m_nodesLayout = new QVBoxLayout(scrollContents);
+    m_nodesLayout->setContentsMargins(10, 0, 10, 0);
+    m_nodesLayout->setSpacing(0);
+    m_nodesLayout->setAlignment(Qt::AlignTop);
     m_nodesLayout->addStretch(1);
     m_scrollArea->setWidget(scrollContents);
     layout->addWidget(m_scrollArea);

--- a/LASSIE/src/dialogs/functions/impl/StochosFunction.cpp
+++ b/LASSIE/src/dialogs/functions/impl/StochosFunction.cpp
@@ -34,6 +34,7 @@ StochosFunction::StochosFunction(QWidget* parent)
     m_offsetEdit = new QLineEdit(this);
     offsetRow->addWidget(m_offsetEdit);
     layout->addLayout(offsetRow);
+    m_offsetEdit->setEnabled(false);
 
     // Scroll area for nodes
     m_scrollArea = new QScrollArea(this);

--- a/LASSIE/src/widgets/MakeEnvelopeRow.cpp
+++ b/LASSIE/src/widgets/MakeEnvelopeRow.cpp
@@ -42,6 +42,8 @@ MakeEnvelopeRow::MakeEnvelopeRow(int index, QWidget* parent)
 
     m_xEdit->setFixedHeight(20);
     m_yEdit->setFixedHeight(20);
+    m_xEdit->setMinimumWidth(70);
+    m_yEdit->setMinimumWidth(70);
 
     connect(m_xFnBtn,    &QPushButton::clicked, this, &MakeEnvelopeRow::onXFnClicked);
     connect(m_yFnBtn,    &QPushButton::clicked, this, &MakeEnvelopeRow::onYFnClicked);

--- a/LASSIE/src/widgets/MakeEnvelopeRow.cpp
+++ b/LASSIE/src/widgets/MakeEnvelopeRow.cpp
@@ -8,7 +8,7 @@ MakeEnvelopeRow::MakeEnvelopeRow(int index, QWidget* parent)
 
     m_vBox = new QVBoxLayout(this);
     m_vBox->setContentsMargins(0, 0, 0, 0);
-    m_vBox->setSpacing(4);
+    m_vBox->setSpacing(0);
 
     m_label   = new QLabel(QString("Node %1:").arg(index + 1));
     m_xEdit   = new QLineEdit;

--- a/LASSIE/src/widgets/MakeEnvelopeRow.cpp
+++ b/LASSIE/src/widgets/MakeEnvelopeRow.cpp
@@ -40,8 +40,8 @@ MakeEnvelopeRow::MakeEnvelopeRow(int index, QWidget* parent)
     m_hBox->addWidget(m_rmBtn);
     m_hBox->addWidget(m_insBtn);
 
-    m_xEdit->setFixedHeight(20);
-    m_yEdit->setFixedHeight(20);
+    m_xEdit->setFixedHeight(30);
+    m_yEdit->setFixedHeight(30);
     m_xEdit->setMinimumWidth(70);
     m_yEdit->setMinimumWidth(70);
 

--- a/LASSIE/src/widgets/MakeEnvelopeRow.cpp
+++ b/LASSIE/src/widgets/MakeEnvelopeRow.cpp
@@ -6,9 +6,9 @@ MakeEnvelopeRow::MakeEnvelopeRow(int index, QWidget* parent)
 {
     setFrameShape(QFrame::NoFrame);
 
-    m_hBox = new QHBoxLayout(this);
-    m_hBox->setContentsMargins(0, 0, 0, 0);
-    m_hBox->setSpacing(4);
+    m_vBox = new QVBoxLayout(this);
+    m_vBox->setContentsMargins(0, 0, 0, 0);
+    m_vBox->setSpacing(4);
 
     m_label   = new QLabel(QString("Point %1:").arg(index + 1));
     m_xEdit   = new QLineEdit;
@@ -28,22 +28,30 @@ MakeEnvelopeRow::MakeEnvelopeRow(int index, QWidget* parent)
     m_rmBtn  = new QPushButton("rm");
     m_insBtn = new QPushButton("ins");
 
-    m_hBox->addWidget(m_label);
-    m_hBox->addWidget(new QLabel("X:"));
-    m_hBox->addWidget(m_xEdit);
-    m_hBox->addWidget(m_xFnBtn);
-    m_hBox->addWidget(new QLabel("Y:"));
-    m_hBox->addWidget(m_yEdit);
-    m_hBox->addWidget(m_yFnBtn);
-    m_hBox->addWidget(m_typeCombo);
-    m_hBox->addWidget(m_proCombo);
-    m_hBox->addWidget(m_rmBtn);
-    m_hBox->addWidget(m_insBtn);
+    auto* firstRow = new QHBoxLayout;
+    auto* secondRow = new QHBoxLayout;
+    auto* thirdRow = new QHBoxLayout;
+
+    firstRow->addWidget(m_label);
+    firstRow->addWidget(new QLabel("X:"));
+    firstRow->addWidget(m_xEdit);
+    firstRow->addWidget(m_xFnBtn);
+    secondRow->addWidget(new QLabel("Y:"));
+    secondRow->addWidget(m_yEdit);
+    secondRow->addWidget(m_yFnBtn);
+    thirdRow->addWidget(m_typeCombo);
+    thirdRow->addWidget(m_proCombo);
+    thirdRow->addWidget(m_rmBtn);
+    thirdRow->addWidget(m_insBtn);
 
     m_xEdit->setFixedHeight(30);
     m_yEdit->setFixedHeight(30);
     m_xEdit->setMinimumWidth(70);
     m_yEdit->setMinimumWidth(70);
+
+    m_vBox->addLayout(firstRow);
+    m_vBox->addLayout(secondRow);
+    m_vBox->addLayout(thirdRow);
 
     connect(m_xFnBtn,    &QPushButton::clicked, this, &MakeEnvelopeRow::onXFnClicked);
     connect(m_yFnBtn,    &QPushButton::clicked, this, &MakeEnvelopeRow::onYFnClicked);

--- a/LASSIE/src/widgets/MakeEnvelopeRow.cpp
+++ b/LASSIE/src/widgets/MakeEnvelopeRow.cpp
@@ -10,7 +10,7 @@ MakeEnvelopeRow::MakeEnvelopeRow(int index, QWidget* parent)
     m_vBox->setContentsMargins(0, 0, 0, 0);
     m_vBox->setSpacing(4);
 
-    m_label   = new QLabel(QString("Point %1:").arg(index + 1));
+    m_label   = new QLabel(QString("Node %1:").arg(index + 1));
     m_xEdit   = new QLineEdit;
     m_xFnBtn  = new QPushButton("fn");
     m_yEdit   = new QLineEdit;

--- a/LASSIE/src/widgets/MakeEnvelopeRow.hpp
+++ b/LASSIE/src/widgets/MakeEnvelopeRow.hpp
@@ -48,7 +48,7 @@ private slots:
 private:
     int m_index;
 
-    QHBoxLayout* m_hBox      = nullptr;
+    QVBoxLayout* m_vBox      = nullptr;
     QLabel*      m_label     = nullptr;
     QLineEdit*   m_xEdit     = nullptr;
     QPushButton* m_xFnBtn    = nullptr;

--- a/LASSIE/src/widgets/Stochos.cpp
+++ b/LASSIE/src/widgets/Stochos.cpp
@@ -39,9 +39,9 @@ Stochos::Stochos(int methodType, int stochosIndex, QWidget *parent)
         stochosHBox->addWidget(m_distEntry);
         stochosHBox->addWidget(m_removeStochosButton);
 
-        m_minEntry->setFixedHeight(20);
-        m_maxEntry->setFixedHeight(20);
-        m_distEntry->setFixedHeight(20);
+        m_minEntry->setFixedHeight(30);
+        m_maxEntry->setFixedHeight(30);
+        m_distEntry->setFixedHeight(30);
 
         m_mainLayout->addLayout(stochosHBox);
     }

--- a/LASSIE/src/widgets/Stochos.cpp
+++ b/LASSIE/src/widgets/Stochos.cpp
@@ -17,10 +17,13 @@ Stochos::Stochos(int methodType, int stochosIndex, QWidget *parent)
         m_mainLayout->setSpacing(10);
         auto* minLabel = new QLabel("Min:");
         m_minEntry = new QLineEdit;
+        m_minEntry->setMinimumWidth(70);
         auto* maxLabel = new QLabel("Max:");
         m_maxEntry = new QLineEdit;
+        m_maxEntry->setMinimumWidth(70);
         auto* distLabel = new QLabel("Distribution:");
         m_distEntry = new QLineEdit;
+        m_distEntry->setMinimumWidth(70);
         m_removeStochosButton = new QPushButton("Remove Node");
 
         connect(m_removeStochosButton, &QPushButton::clicked, this, &Stochos::onRemoveNodeClicked);

--- a/LASSIE/src/widgets/Stochos.cpp
+++ b/LASSIE/src/widgets/Stochos.cpp
@@ -13,7 +13,7 @@ Stochos::Stochos(int methodType, int stochosIndex, QWidget *parent)
     QHBoxLayout* stochosHBox = new QHBoxLayout();
 
     if (methodType == 0) {
-        m_mainLayout->setContentsMargins(10, 10, 10, 10);
+        m_mainLayout->setContentsMargins(10, 0, 10, 0);
         m_mainLayout->setSpacing(10);
         auto* minLabel = new QLabel("Min:");
         m_minEntry = new QLineEdit;

--- a/LASSIE/src/widgets/generic/FunctionEntryRow.cpp
+++ b/LASSIE/src/widgets/generic/FunctionEntryRow.cpp
@@ -33,7 +33,7 @@ FunctionEntryRow::FunctionEntryRow(const QString& labelText,
     connect(m_entry,    &QLineEdit::textChanged,         this, &FunctionEntryRow::onTextChanged);
     connect(m_entry,    &QLineEdit::cursorPositionChanged, this, [this](){ emit editFocused(m_entry); });
 
-    m_entry->setFixedHeight(20);
+    m_entry->setFixedHeight(30);
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 }
 


### PR DESCRIPTION
MakeSieve: lines closer, makes entry higher
MakeEnvelope: separate line for x entry, y entry, and functions; makes entry higher; change "point" to "node"
Stochos: gray out "offset", lines closer, makes entry higher
Select: nodes closer to each other
I also changed multiEntryFunction so that all multi-entry functions, e.g. randomInt, EnvLib, etc., have closer entry lines. 
Solves #128 