### PR TITLE
Restore multiple consecutive CMOD runs

### DIFF
--- a/CMOD/src/piece-experimental.cpp
+++ b/CMOD/src/piece-experimental.cpp
@@ -316,9 +316,25 @@ Piece::Piece(string _workingPath, string _projectTitle){
     cin>>seed;
   }
 
+  // Run multiple consecutive builds from a single seed.
+  int numRuns = 1;
+  cout<<"Please key in how many times you want to run (1-10):"<<endl;
+  if (!(cin>>numRuns)) {
+    cerr<<"Invalid number of runs; defaulting to 1."<<endl;
+    cin.clear();
+    numRuns = 1;
+  }
+
+  if (numRuns < 1) { numRuns = 1; }
+  if (numRuns > 10) { numRuns = 10; }
+
   //Convert seed string to seed number and seed the random number generator
   int seedNumber = PieceHelper::getSeedNumber(seed);
   Random::Seed((unsigned int)seedNumber);
+
+  // Seed only once so each run continues the same random sequence.
+  for (int run = 0; run < numRuns; run++) {
+  cout<<"RUN NUMBER #" << run + 1 <<endl;
 
   //construct the utilities object
   utilities = new Utilities(root,
@@ -451,6 +467,8 @@ Piece::Piece(string _workingPath, string _projectTitle){
   //clean up
   delete utilities;
   delete topEvent; //wait till the thread join
+
+  }
 
 }
 

--- a/LASSIE/src/windows/MainWindow.cpp
+++ b/LASSIE/src/windows/MainWindow.cpp
@@ -346,6 +346,11 @@ void MainWindow::runProject()
     pm->seed() = seed;
     pm->writeSeedEntry(seed);
 
+    const int numRuns = QInputDialog::getInt(this, tr("Number of runs"),
+                                             tr("Enter the number of runs:"),
+                                             1, 1, 10, 1, &ok);
+    if(!ok) return;
+
     using namespace Qt::StringLiterals;
 
     const auto cmod = new QProcess(this);
@@ -355,6 +360,10 @@ void MainWindow::runProject()
                 statusBar()->showMessage(tr("CMOD exited with code %1").arg(exit_code)); 
             }
         );
+    connect(cmod, &QProcess::started, cmod, [cmod, numRuns] {
+        cmod->write(QByteArray::number(numRuns) + '\n');
+        cmod->closeWriteChannel();
+    });
     const QString cmodBinary = resolveCmodBinary();
     qDebug() << "Project run with string:" << cmodBinary + " " + pm->fileinfo().canonicalFilePath();
 


### PR DESCRIPTION
Restores the DISSCO 2.1.0 multiple-run behavior in 2.2.0.
- Prompts for 1–10 consecutive runs using a single seed.
- Reinitializes and cleans up CMOD state for each run.
- Adds a LASSIE dialog and passes the run count to CMOD.
- Preserves uniquely numbered AIFF and PDF outputs.