### PR TITLE
layerbox: center the text & expand labels to fill the table

### DIFF
--- a/LASSIE/src/widgets/LayerBox.cpp
+++ b/LASSIE/src/widgets/LayerBox.cpp
@@ -42,10 +42,11 @@ LayerBox::LayerBox(Eventtype eventType, int eventIndex, int layerIndex, QWidget*
     m_model->setHorizontalHeaderLabels({"Child Type", "Class", "Name",
         "Weight", "Attack Env.", "A. Env. Scaler", "Duration Env.", "D. Env. Scaler"});
 
-    m_treeView->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
-    m_treeView->header()->setStretchLastSection(false);
-
+    m_treeView->header()->setSectionResizeMode(QHeaderView::Stretch);
+    m_treeView->header()->setStretchLastSection(true);
+    m_treeView->header()->setDefaultAlignment(Qt::AlignCenter);
     m_treeView->setModel(m_model);
+
     m_treeView->setSelectionBehavior(QAbstractItemView::SelectRows);
     m_treeView->setSelectionMode(QAbstractItemView::ExtendedSelection);
     m_treeView->setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::SelectedClicked);


### PR DESCRIPTION
closes #132 , center the text and expand labels to fill the table, as the image shows.
<img width="1494" height="534" alt="image" src="https://github.com/user-attachments/assets/2b0c5d5c-80d7-441a-8b92-b03a72da5f2b" />
