### PR TITLE
Fix per-note modifiers and process output handling

### DIFF
--- a/CMOD/src/Main.cpp
+++ b/CMOD/src/Main.cpp
@@ -98,6 +98,7 @@ int main(int parameterCount, char **parameterList) {
 
   //Create the piece!
   Piece* piece = new Piece(workingPath, projectName);
+  const bool buildSucceeded = piece->completedSuccessfully();
   delete piece;
   //delete outputFile;		//Sever
 
@@ -111,6 +112,6 @@ int main(int parameterCount, char **parameterList) {
   printf("Computation Time: %02d:%02d:%02d.\n", hr, min, sec);
 
 
-  return 0;
+  return buildSucceeded ? 0 : 1;
 
 }

--- a/CMOD/src/Note.cpp
+++ b/CMOD/src/Note.cpp
@@ -39,34 +39,42 @@ using namespace std;
 
 //----------------------------------------------------------------------------//
 
-Note::Note(TimeSpan ts, const Event* root_exact_ancestor) : ts(ts), rootExactAncestor(root_exact_ancestor),
-  pitchNum(0), octaveNum(0), octavePitch(0), loudnessNum(0), type(NoteType::kUnknown) {
+Note::Note(TimeSpan ts, const Event* root_exact_ancestor)
+    : ts(ts),
+      rootExactAncestor(root_exact_ancestor),
+      pitchNum(0),
+      octaveNum(0),
+      octavePitch(0),
+      loudnessNum(0),
+      start_t(0),
+      end_t(0),
+      tuplet(0),
+      split(0),
+      staffNum(0),
+      type(NoteType::kUnknown),
+      first_notation_fragment(true) {
 }
 
 //----------------------------------------------------------------------------//
 
-Note::Note() : type(NoteType::kUnknown) {
+Note::Note()
+    : rootExactAncestor(nullptr),
+      pitchNum(0),
+      octaveNum(0),
+      octavePitch(0),
+      loudnessNum(0),
+      start_t(0),
+      end_t(0),
+      tuplet(0),
+      split(0),
+      staffNum(0),
+      type(NoteType::kUnknown),
+      first_notation_fragment(true) {
 }
 
 //----------------------------------------------------------------------------//
 
-Note::Note(const Note& other) {
-  start_t = other.start_t;
-  end_t = other.end_t;
-  pitch_out = other.pitch_out;
-  ts = other.ts;
-  rootExactAncestor = other.rootExactAncestor;
-  pitchNum = other.pitchNum;
-  octaveNum = other.octaveNum;
-  octavePitch = other.octavePitch;
-  pitchName = other.pitchName;
-  loudnessNum = other.loudnessNum;
-  loudnessMark = other.loudnessMark;
-  loudness_out = other.loudness_out;
-  modifiers = other.modifiers;
-  type = other.type;
-  staffNum = other.staffNum;
-}
+Note::Note(const Note& other) = default;
 
 //----------------------------------------------------------------------------//
 
@@ -101,10 +109,12 @@ void Note::setPitchWellTempered(int absPitchNum) {
   octavePitch = pitchNum % 12;
   pitchName = pitchNames[octavePitch];
 
-  pitch_out = OutNames[octavePitch];
+  string pitch = OutNames[octavePitch];
   string signs[8] = {",,,",",,",",","","'","''","'''","''''"};
   string sign = signs[octaveNum];
-  pitch_out = "<" + pitch_out + sign + ">";
+  chord_tones.clear();
+  chord_tones.push_back({pitch + sign, modifiers, INT_MIN});
+  rebuildPitchOutput();
 
   
   Output::addProperty("Pitch Number", pitchNum, "semitones");
@@ -213,21 +223,99 @@ bool is_attach_mark(string mod_name){
 //----------------------------------------------------------------------------//
 
 void Note::setModifiers(vector<string> modNames) {
+  modifiers.clear();
   for(unsigned i = 0; i < modNames.size(); i++) {
     if (is_attach_mark(modNames[i])){
-      string temp = "\\" + modNames[i];
-      modifiers_out.push_back(temp);
+      modifiers.push_back("\\" + modNames[i]);
+    }
+  }
+
+  if (chord_tones.size() == 1) {
+    chord_tones.front().modifiers = modifiers;
+  }
+}
+//----------------------------------------------------------------------------//
+
+void Note::prepareForInsertion() {
+  for (ChordTone& tone : chord_tones) {
+    if (tone.attack_edu == INT_MIN) {
+      tone.attack_edu = start_t;
+    }
+  }
+  rebuildPitchOutput();
+}
+
+void Note::mergePitches(const Note& other, bool prepend_other) {
+  if (prepend_other) {
+    chord_tones.insert(
+        chord_tones.begin(), other.chord_tones.begin(), other.chord_tones.end());
+  } else {
+    chord_tones.insert(
+        chord_tones.end(), other.chord_tones.begin(), other.chord_tones.end());
+  }
+  rebuildPitchOutput();
+}
+
+void Note::beginNotation() {
+  first_notation_fragment = true;
+}
+
+string Note::nextPitchOutput() {
+  const string output = renderPitch(first_notation_fragment);
+  first_notation_fragment = false;
+  return output;
+}
+
+string Note::renderPitch(bool include_modifiers) const {
+  if (chord_tones.empty()) {
+    return pitch_out;
+  }
+
+  string output = "<";
+  for (size_t tone_idx = 0; tone_idx < chord_tones.size(); ++tone_idx) {
+    if (tone_idx > 0) {
+      output += " ";
+    }
+
+    const ChordTone& tone = chord_tones[tone_idx];
+    output += tone.pitch;
+    if (include_modifiers && tone.attack_edu == start_t) {
+      for (vector<string>::const_reverse_iterator modifier = tone.modifiers.rbegin();
+           modifier != tone.modifiers.rend();
+           ++modifier) {
+        output += *modifier;
+      }
+    }
+  }
+  output += ">";
+  return output;
+}
+
+void Note::rebuildPitchOutput() {
+  if (!chord_tones.empty()) {
+    pitch_out = renderPitch(false);
+  }
+}
+
+void Note::adjustStartTime(int new_start_time) {
+  for (ChordTone& tone : chord_tones) {
+    if (tone.attack_edu == start_t) {
+      tone.attack_edu = new_start_time;
+    }
+  }
+  start_t = new_start_time;
+}
+
+void Note::shiftEDUs(int offset) {
+  start_t += offset;
+  end_t += offset;
+  for (ChordTone& tone : chord_tones) {
+    if (tone.attack_edu != INT_MIN) {
+      tone.attack_edu += offset;
     }
   }
 }
 
-//----------------------------------------------------------------------------//
-
-void Note::mergeModifiers(vector<string> modNames_out){
-  for(size_t i=0; i<modNames_out.size();i++){
-    modifiers_out.push_back(modNames_out.at(i));
-  }
-}
 //----------------------------------------------------------------------------//
 
 // multistaffs

--- a/CMOD/src/Note.h
+++ b/CMOD/src/Note.h
@@ -71,6 +71,20 @@ struct NoteType {
 class Note {
   friend class Section;
 
+    /**
+     * A pitch within a notated chord.
+     *
+     * Modifiers belong to the individual pitch event, not to the chord that
+     * Section may create while laying out simultaneous or overlapping notes.
+     * attack_edu records the event's original attack so tied continuation
+     * segments do not repeat its modifiers.
+     */
+    struct ChordTone {
+      std::string pitch;
+      std::vector<std::string> modifiers;
+      int attack_edu;
+    };
+
     		//Rhythm//
 
     //The timespan of the note.
@@ -100,8 +114,11 @@ class Note {
     //Dynamic marking (i.e. "ff")
     std::string loudnessMark;
 
-    //Modifiers
-    std::vector<std::string> modifiers; //string names of the modifiers
+    // Validated LilyPond modifier commands for this individual event.
+    std::vector<std::string> modifiers;
+
+    // Individual pitch events retained when Section groups them as a chord.
+    std::vector<ChordTone> chord_tones;
     
     /* variables for output notes */
     string pitch_out;
@@ -115,12 +132,21 @@ class Note {
     string tuplet_name;
     int split;
 
-    std::vector<std::string> modifiers_out;
-
     //Absolute numeric value of the Staff
     int staffNum;
 
     NoteType::type type;
+
+    bool first_notation_fragment;
+
+    void prepareForInsertion();
+    void mergePitches(const Note& other, bool prepend_other = false);
+    void beginNotation();
+    std::string nextPitchOutput();
+    std::string renderPitch(bool include_modifiers) const;
+    void rebuildPitchOutput();
+    void adjustStartTime(int new_start_time);
+    void shiftEDUs(int offset);
 
   public:
     /**
@@ -205,8 +231,6 @@ class Note {
      *  \param modNames
      **/
     void setModifiers(std::vector<std::string> modNames);
-    void mergeModifiers(std::vector<std::string> modNames_out);
-
     /**
      * Set or get the staff number of this Note.
     **/

--- a/CMOD/src/Output.cpp
+++ b/CMOD/src/Output.cpp
@@ -21,9 +21,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "Note.h"
 // #include "Note.cpp"
 
-OutputNode* Output::top;
-ofstream* Output::particelFile;
-int Output::level;
+OutputNode* Output::top = nullptr;
+ofstream* Output::particelFile = nullptr;
+int Output::level = -1;
 NotationScore Output::notation_score_;
 
 OutputNode::OutputNode(string name) : nodeName(name) {
@@ -179,7 +179,10 @@ void Output::initialize(string particelFilename) {
 void Output::free(void)
 {
   delete top;
+  top = nullptr;
   delete particelFile;
+  particelFile = nullptr;
+  level = -1;
 }
 
 
@@ -214,6 +217,12 @@ void Output::beginSubLevel(string name) {
 //----------------------------------------------------------------------------//
 
 void Output::addProperty(string name, string value, string units) {
+  // Note attributes are also needed for score rendering, so their setters call
+  // this method even when the optional Particel report is disabled. In that
+  // state there is intentionally no output tree and nothing to record.
+  if(!particelFile)
+    return;
+
   OutputNode* current = getCurrentLevelNode();
   if(!current)
     cerr << "Warning: Top level does not exist. Property can not be added."

--- a/CMOD/src/Piece.h
+++ b/CMOD/src/Piece.h
@@ -115,6 +115,9 @@ class Piece {
   **/
   ~Piece();
 
+  /// Returns false when an external score-generation step failed.
+  bool completedSuccessfully() const { return buildSucceeded; }
+
   /**
   * Prints information about the piece.
   **/
@@ -170,6 +173,7 @@ class Piece {
   int sampleRate;
   int sampleSize;
   int numThreads;
+  bool buildSucceeded = true;
 
 };
 

--- a/CMOD/src/Section.cpp
+++ b/CMOD/src/Section.cpp
@@ -98,6 +98,7 @@ bool Section::InsertNote(Note* n) {
   n->type = NoteType::kNote;
   is_built_ = false;
 
+  n->prepareForInsertion();
   EnsureNoteExpressible(n);
 
   if (n->end_t <= n->start_t ) {
@@ -141,10 +142,8 @@ bool Section::InsertNote(Note* n) {
       if(cur->end_t == n->end_t){
         // if the end time is still the same
         cur->split = n->split;
-        // merge the modifiers together
-        cur->mergeModifiers(n->modifiers_out);
-        // merge the notes together: Ex: <c'> + <e'> -> <c'e'>
-        cur->pitch_out = cur->pitch_out.substr(0, cur->pitch_out.length() - 1) + " " + n->pitch_out.substr(1);
+        // Group the pitches while retaining each event's own modifiers.
+        cur->mergePitches(*n);
         return true;
       }
       else if (cur->end_t > n->end_t){
@@ -152,8 +151,7 @@ bool Section::InsertNote(Note* n) {
         // merge the overlap part and insert the left of existnode again
         cur->start_t = n->end_t;
         n->split = 1;
-        n->mergeModifiers(cur->modifiers_out);
-        n->pitch_out = cur->pitch_out.substr(0, cur->pitch_out.length() - 1) + " " + n->pitch_out.substr(1);
+        n->mergePitches(*cur, true);
         InsertNote(n);
         return true;
       }
@@ -162,8 +160,7 @@ bool Section::InsertNote(Note* n) {
           // insertnote has the longer end time and ensure they have the overlap part.
           // merge the overlap part, and insert the left of insernote 
           cur->split = 1;
-          cur->mergeModifiers(n->modifiers_out);
-          cur->pitch_out = cur->pitch_out.substr(0, cur->pitch_out.length() - 1) + " " + n->pitch_out.substr(1);
+          cur->mergePitches(*n);
           n->start_t = cur->end_t;
         }
       }
@@ -175,8 +172,7 @@ bool Section::InsertNote(Note* n) {
         // shorten the existnode and merge the overlap part
         cur->split =1;
         cur->end_t = n->start_t;
-        n->mergeModifiers(cur->modifiers_out);
-        n->pitch_out = cur->pitch_out.substr(0, cur->pitch_out.length() - 1) + " " + n->pitch_out.substr(1);
+        n->mergePitches(*cur, true);
       }
       else if (cur->end_t > n->end_t){
         // if insertnode ends early
@@ -187,8 +183,7 @@ bool Section::InsertNote(Note* n) {
         cur->split = 1;
         sec_chord->start_t = n->end_t;
         n->split = 1;
-        n->mergeModifiers(cur->modifiers_out);
-        n->pitch_out = cur->pitch_out.substr(0, cur->pitch_out.length() - 1) + " " + n->pitch_out.substr(1);
+        n->mergePitches(*cur, true);
         InsertNote(sec_chord);
         InsertNote(n);
         return true;
@@ -197,8 +192,7 @@ bool Section::InsertNote(Note* n) {
         // if insertnode ends later.
         Note* sec_chord = new Note(*n);
         sec_chord->end_t = cur->end_t;
-        sec_chord->mergeModifiers(cur->modifiers_out);
-        sec_chord->pitch_out = cur->pitch_out.substr(0, cur->pitch_out.length() - 1) + " " + n->pitch_out.substr(1);
+        sec_chord->mergePitches(*cur, true);
         sec_chord->split = 1;
         cur->end_t = sec_chord->start_t;
         cur->split = 1;
@@ -213,8 +207,7 @@ bool Section::InsertNote(Note* n) {
       if(cur->end_t == n->end_t){
         // if they ends at the same time
         cur->split = n->split;
-        cur->mergeModifiers(n->modifiers_out);
-        cur->pitch_out = cur->pitch_out.substr(0, cur->pitch_out.length() - 1) + " " + n->pitch_out.substr(1);
+        cur->mergePitches(*n);
         n->end_t = cur->start_t;
         n->split = 1;
         InsertNote(n);
@@ -402,7 +395,7 @@ void Section::AddRestsAndFlatten() {
         if(it+1 == section_[i].end()){
           prev->end_t = cur->start_t; // Can't shorten current note because end of bar
         } else {
-          cur->start_t = prev->end_t;
+          cur->adjustStartTime(prev->end_t);
         }
       }
       section_flat_.push_back(cur);
@@ -450,7 +443,8 @@ void Section::Notate() {
         if (next_it != section_flat_.end()) {
           Note* next_note = *next_it;
           if (next_note != 0) {
-            next_note->start_t = cur->start_t + dur_beats * time_signature_.beat_edus_ + best_fit;
+            next_note->adjustStartTime(
+                cur->start_t + dur_beats * time_signature_.beat_edus_ + best_fit);
           }
         }
       }
@@ -465,6 +459,7 @@ void Section::Notate() {
       continue;
     }
 
+    cur->beginNotation();
     tuplet_dur = NotateCurrentNote(cur, &prev_tuplet, tuplet_dur);
   }
 }
@@ -524,8 +519,9 @@ void Section::CapEnding() {
 
     int offset = last_bar.front()->start_t;
     while (!last_bar.empty()) {
-      last_bar.front()->start_t -= offset; // make notes in cap start from 0
-      last_bar.front()->end_t -= offset;
+      // Make notes in the cap start from 0 while preserving the original
+      // attack of every individual pitch in a grouped chord.
+      last_bar.front()->shiftEDUs(-offset);
 
       if (!cap_->InsertNote(last_bar.front())) {
         cerr << "Note could not be inserted into end cap. " <<
@@ -602,14 +598,12 @@ int Section::FillCurrentTupletDur(Note* current_note,
     int unit = tuplet_dur / (time_signature_.beat_edus_ / prev_tuplet);
     if(unit == 3) {
       string s = Note::int_to_str(time_signature_.unit_note_ * 2);
-      current_note->type_out += current_note->pitch_out + s + ".";
+      current_note->type_out += current_note->nextPitchOutput() + s + ".";
       LoudnessMark(current_note);  // this places all the dynamic marks at the beginning of a sound
-      ModifiersMark(current_note);
     } else {
       string s = Note::int_to_str(time_signature_.unit_note_ * prev_tuplet / unit);
-      current_note->type_out += current_note->pitch_out + s;
+      current_note->type_out += current_note->nextPitchOutput() + s;
       LoudnessMark(current_note);  // this places all the dynamic marks at the beginning of a sound
-      ModifiersMark(current_note);
     }
     if ((dur > tuplet_dur || current_note->split == 1) && 
        (current_note->pitch_out != "r")) {
@@ -639,15 +633,14 @@ int Section::FillCompleteBeats(Note* current_note, int remaining_dur) {
   int remainder = remaining_dur % time_signature_.beat_edus_;
   int mainDur = remaining_dur / time_signature_.beat_edus_;
   // LoudnessMark(current_note);  // this places all the dynamic marks at the beginning of a sound
-  // ModifiersMark(current_note);
   while (mainDur > 0) {
     int power_of_2 = TimeSignature::DiscreteLog2(time_signature_.unit_note_);
     while (power_of_2 >= 0) {
       int beats = TimeSignature::Power(2, power_of_2);
       if (mainDur >= beats) {
-        current_note->type_out += current_note->pitch_out + Note::int_to_str(time_signature_.unit_note_ / beats);
+        current_note->type_out += current_note->nextPitchOutput()
+            + Note::int_to_str(time_signature_.unit_note_ / beats);
         LoudnessMark(current_note);  // this places all the dynamic marks at the beginning of a sound
-        ModifiersMark(current_note);
         
         mainDur -= beats;
         if (mainDur >= beats / 2 && beats >= 2){
@@ -700,14 +693,12 @@ int Section::CreateTupletWithRests(Note* current_note,
   if (tuplet_type == 2 || tuplet_type == 4) {
     if (remaining_dur / (time_signature_.beat_edus_ / tuplet_type) == 3) {
       string s = Note::int_to_str(time_signature_.unit_note_ * 2);
-      current_note->type_out += current_note->pitch_out + s + ". ";
+      current_note->type_out += current_note->nextPitchOutput() + s + ". ";
       LoudnessMark(current_note);  // this places all the dynamic marks at the beginning of a sound
-      ModifiersMark(current_note);
     } else {
       string s = Note::int_to_str(time_signature_.unit_note_ * tuplet_type);
-      current_note->type_out += current_note->pitch_out + s + " ";
+      current_note->type_out += current_note->nextPitchOutput() + s + " ";
       LoudnessMark(current_note);  // this places all the dynamic marks at the beginning of a sound
-      ModifiersMark(current_note);
     }
     tuplet_dur = time_signature_.beat_edus_ - remaining_dur;
   } else if (tuplet_type != -1) {
@@ -724,7 +715,6 @@ int Section::CreateTupletWithRests(Note* current_note,
 }
 
 void Section::NoteInTuplet(Note* current_note, int tuplet_type, int duration) {
-  string pitch = current_note->pitch_out;
   bool first = true;
 
   int beat = duration / (time_signature_.beat_edus_ / tuplet_type); // working in tuplet beats
@@ -736,7 +726,8 @@ void Section::NoteInTuplet(Note* current_note, int tuplet_type, int duration) {
     while(power_of_2 >= 0){
       int beats = TimeSignature::Power(2, power_of_2);
       if(beat >= beats){
-        current_note->type_out += current_note->pitch_out + Note::int_to_str(unit_in_tuplet / beats);
+        current_note->type_out += current_note->nextPitchOutput()
+            + Note::int_to_str(unit_in_tuplet / beats);
         //Rubin Du 2024: The dot has to be right after duration but not after modifier
         beat -= beats;
         if(beat >= beats/2 && beats >= 2){
@@ -744,7 +735,6 @@ void Section::NoteInTuplet(Note* current_note, int tuplet_type, int duration) {
           beat -= beats/2;
         }
         LoudnessMark(current_note);  // this places all the dynamic marks at the beginning of a sound
-        ModifiersMark(current_note);
         break;
       }
       power_of_2--;
@@ -758,7 +748,6 @@ void Section::NoteInTuplet(Note* current_note, int tuplet_type, int duration) {
     }
 
     if(first == true){
-      ModifiersMark(current_note);
       LoudnessMark(current_note);
       first = false;
     }
@@ -770,13 +759,6 @@ void Section::LoudnessMark(Note* current_note) {
       current_note->pitch_out != "r") {
   	current_note->type_out += current_note->loudness_out + " ";
   	prev_loudness = current_note->loudness_out;
-  }
-}
-
-void Section::ModifiersMark(Note* current_note) {
-  while (!current_note->modifiers_out.empty()){
-    current_note->type_out += current_note->modifiers_out.back() + " ";
-    current_note->modifiers_out.pop_back();
   }
 }
 

--- a/CMOD/src/Section.h
+++ b/CMOD/src/Section.h
@@ -265,13 +265,6 @@ private:
   void LoudnessMark(Note* current_note);
 
   /**
-   * Add a modifier to the current note.
-   * 
-   * @param current_note The note to which to add a modifier
-  **/
-  void ModifiersMark(Note* current_note);
-
-  /**
    * Get the first bar of this Section after building and
    * __remove the full bar from this Section__
    * 

--- a/CMOD/src/piece-experimental.cpp
+++ b/CMOD/src/piece-experimental.cpp
@@ -419,6 +419,7 @@ Piece::Piece(string _workingPath, string _projectTitle){
   int lilypondStatus = system(lilypondCommand.c_str());
 
   if (lilypondStatus != 0) {
+    buildSucceeded = false;
     cerr << "Error: LilyPond failed to generate "
        << projectName << ".pdf" << endl;
   }
@@ -441,6 +442,7 @@ Piece::Piece(string _workingPath, string _projectTitle){
     string targetPdf = "ScoreFiles/" + projectName + suffix + ".pdf";
 
     if (rename(sourcePdf.c_str(), targetPdf.c_str()) != 0) {
+      buildSucceeded = false;
       cerr << "Error: could not move " << sourcePdf
           << " to " << targetPdf
           << " (" << strerror(errno) << ")" << endl;

--- a/LASSIE/CMakeLists.txt
+++ b/LASSIE/CMakeLists.txt
@@ -62,6 +62,7 @@ qt_add_executable(LASSIE
     src/core/project_struct.cpp src/core/project_struct.hpp
     src/widgets/PaletteViewController.cpp src/widgets/PaletteViewController.hpp
     src/widgets/EventAttributesViewController.cpp src/widgets/EventAttributesViewController.hpp src/ui/Attributes.ui
+    src/widgets/NoteModifierSelection.cpp src/widgets/NoteModifierSelection.hpp
     src/dialogs/FileNewObject.cpp src/dialogs/FileNewObject.hpp src/ui/FileNewObject.ui
     src/widgets/LayerBox.cpp src/widgets/LayerBox.hpp
     src/widgets/Partials.cpp src/widgets/Partials.hpp

--- a/LASSIE/src/widgets/EventAttributesViewController.cpp
+++ b/LASSIE/src/widgets/EventAttributesViewController.cpp
@@ -9,10 +9,12 @@
 #include "../widgets/LayerBox.hpp"
 #include "../widgets/Partials.hpp"
 #include "../widgets/Modifiers.hpp"
+#include "NoteModifierSelection.hpp"
 #include "../ui/ui_Modifiers.h"
 
 #include <QMessageBox>
 #include <QKeyEvent>
+#include <QCheckBox>
 #include <QScrollBar>
 #include <QTimer>
 #include <QMetaObject>
@@ -150,6 +152,12 @@ EventAttributesViewController::EventAttributesViewController(ProjectView* projec
 
     ui->layersLayout->setSpacing(8);
     ui->layersLayout->setContentsMargins(0, 0, 0, 0);
+
+    for (QCheckBox* checkBox : ui->notePage->findChildren<QCheckBox*>()) {
+        connect(checkBox, &QCheckBox::toggled, this, [](bool) {
+            MUtilities::modified();
+        });
+    }
 }
 
 EventAttributesViewController::~EventAttributesViewController() = default;
@@ -507,6 +515,10 @@ void EventAttributesViewController::saveCurrentShownEventData() {
             NoteEvent& event = pm->noteevents()[m_curreventindex];
             event.name = ui->noteNameEntry->text();
             event.note_info.staffs = ui->staffNumberEntry->text();
+            const QList<QCheckBox*> checkBoxes =
+                ui->notePage->findChildren<QCheckBox*>();
+            event.note_info.modifiers = NoteModifierSelection::save(
+                event.note_info.modifiers, checkBoxes);
         } else if (type == filter) {
             FilterEvent& event = pm->filterevents()[m_curreventindex];
             event.name = ui->filNameEntry->text();
@@ -827,6 +839,9 @@ void EventAttributesViewController::showCurrentEventData() {
             ui->noteNameEntry->setText(event.name);
             ui->noteNameEntry->setEnabled(false);
             ui->staffNumberEntry->setText(event.note_info.staffs);
+            NoteModifierSelection::load(
+                event.note_info.modifiers,
+                ui->notePage->findChildren<QCheckBox*>());
         }else if(type == filter){
             const FilterEvent& event = pm->filterevents()[m_curreventindex];
             ui->filNameEntry->setText(event.name);

--- a/LASSIE/src/widgets/NoteModifierSelection.cpp
+++ b/LASSIE/src/widgets/NoteModifierSelection.cpp
@@ -1,0 +1,41 @@
+#include "NoteModifierSelection.hpp"
+
+#include <QCheckBox>
+#include <QSignalBlocker>
+
+namespace NoteModifierSelection {
+
+QStringList save(
+    const QStringList& existingModifiers,
+    const QList<QCheckBox*>& checkBoxes)
+{
+    QStringList visibleModifierNames;
+    QStringList selectedModifiers;
+    for (QCheckBox* checkBox : checkBoxes) {
+        visibleModifierNames.append(checkBox->text());
+        if (checkBox->isChecked())
+            selectedModifiers.append(checkBox->text());
+    }
+
+    // A project may contain custom modifiers that this version of the editor
+    // cannot display. Keep those values instead of deleting them on save.
+    for (const QString& modifier : existingModifiers) {
+        if (!visibleModifierNames.contains(modifier)
+            && !selectedModifiers.contains(modifier)) {
+            selectedModifiers.append(modifier);
+        }
+    }
+    return selectedModifiers;
+}
+
+void load(
+    const QStringList& modifiers,
+    const QList<QCheckBox*>& checkBoxes)
+{
+    for (QCheckBox* checkBox : checkBoxes) {
+        const QSignalBlocker blocker(checkBox);
+        checkBox->setChecked(modifiers.contains(checkBox->text()));
+    }
+}
+
+} // namespace NoteModifierSelection

--- a/LASSIE/src/widgets/NoteModifierSelection.hpp
+++ b/LASSIE/src/widgets/NoteModifierSelection.hpp
@@ -1,0 +1,21 @@
+#ifndef NOTEMODIFIERSELECTION_HPP
+#define NOTEMODIFIERSELECTION_HPP
+
+#include <QList>
+#include <QStringList>
+
+class QCheckBox;
+
+namespace NoteModifierSelection {
+
+QStringList save(
+    const QStringList& existingModifiers,
+    const QList<QCheckBox*>& checkBoxes);
+
+void load(
+    const QStringList& modifiers,
+    const QList<QCheckBox*>& checkBoxes);
+
+} // namespace NoteModifierSelection
+
+#endif // NOTEMODIFIERSELECTION_HPP

--- a/LASSIE/src/windows/PostWindow.cpp
+++ b/LASSIE/src/windows/PostWindow.cpp
@@ -1,14 +1,15 @@
 #include "PostWindow.hpp"
 
-#include "../inst.hpp"
-
 #include <QMessageBox>
 #include <QCloseEvent>
 #include <QShortcut>
 //#include <QOverload>
 
 #include <QVBoxLayout>
+#include <QTextCursor>
 #include <QTextCharFormat>
+
+#include <algorithm>
 
 PostWindow::PostWindow(QProcess *process, QWidget *parent)
     : QWidget(parent, Qt::Window), proc(process)
@@ -53,7 +54,7 @@ PostWindow::PostWindow(QProcess *process, QWidget *parent)
     connect(killProc, &QAction::triggered, this, &PostWindow::killProcess);
     connect(runProc, &QAction::triggered, this, &PostWindow::runProcess);
     
-    connect(proc, &QProcess::stateChanged, this, [=]{
+    connect(proc, &QProcess::stateChanged, this, [this, termProc, killProc, runProc]{
         if(proc->state() != QProcess::NotRunning){
             termProc->setEnabled(true);
             killProc->setEnabled(true);
@@ -61,15 +62,47 @@ PostWindow::PostWindow(QProcess *process, QWidget *parent)
         }else{
             termProc->setEnabled(false);
             killProc->setEnabled(false);
+            runProc->setEnabled(true);
         }
     });
 
-    connect(proc, &QProcess::finished, this, [=]{
+    connect(proc, &QProcess::started, this, [this] {
+        resetProcessOutputState();
+    });
+
+    connect(proc, &QProcess::finished, this,
+            [this, runProc](int exitCode, QProcess::ExitStatus exitStatus) {
+        // Drain anything emitted immediately before the process exited.
+        handleStdout();
+        handleStderr();
+
         runProc->setEnabled(true);
-        if(proc->exitStatus() == QProcess::NormalExit)
-            appendColored("*** Process exited normally (exit code " + QString::number(proc->exitCode()) + ") ***", Qt::black);
-        else
-            appendColored("*** Process crashed (abnormal exit; exit code " + QString::number(proc->exitCode()) + ") *** ", Qt::red);
+        const bool succeeded =
+            exitStatus == QProcess::NormalExit && exitCode == 0;
+        if (succeeded) {
+            appendColored(
+                "*** Process exited normally (exit code 0) ***",
+                Qt::black);
+        } else {
+            recolorStderr(Qt::red);
+            const QString summary = exitStatus == QProcess::NormalExit
+                ? QStringLiteral("*** Process failed (exit code %1) ***")
+                      .arg(exitCode)
+                : QStringLiteral(
+                      "*** Process crashed (abnormal exit; exit code %1) ***")
+                      .arg(exitCode);
+            appendColored(summary, Qt::red);
+        }
+    });
+
+    connect(proc, &QProcess::errorOccurred, this,
+            [this](QProcess::ProcessError error) {
+        if (error == QProcess::FailedToStart) {
+            appendColored(
+                QStringLiteral("*** Process failed to start: %1 ***")
+                    .arg(proc->errorString()),
+                Qt::red);
+        }
     });
     
     QVBoxLayout *layout = new QVBoxLayout(this);
@@ -123,16 +156,60 @@ void PostWindow::appendColored(const QString &text, const QColor &color)
     scrollToBottom();
 }
 
+void PostWindow::appendProcessText(const QString &text, bool fromStderr)
+{
+    if (text.isEmpty()) {
+        return;
+    }
+
+    QTextCursor cursor = textEdit->textCursor();
+    cursor.movePosition(QTextCursor::End);
+
+    QTextCharFormat format;
+    format.setForeground(Qt::black);
+
+    const int start = cursor.position();
+    cursor.insertText(text, format);
+    const int end = cursor.position();
+    textEdit->setTextCursor(cursor);
+
+    if (fromStderr) {
+        stderrRanges.push_back({start, end});
+    }
+
+    scrollToBottom();
+}
+
+void PostWindow::recolorStderr(const QColor &color)
+{
+    QTextCharFormat format;
+    format.setForeground(color);
+
+    for (const TextRange &range : stderrRanges) {
+        QTextCursor cursor(textEdit->document());
+        cursor.setPosition(range.start);
+        cursor.setPosition(range.end, QTextCursor::KeepAnchor);
+        cursor.mergeCharFormat(format);
+    }
+}
+
+void PostWindow::resetProcessOutputState()
+{
+    stdoutDecoder.resetState();
+    stderrDecoder.resetState();
+    stderrRanges.clear();
+}
+
 void PostWindow::handleStdout()
 {
-    QString data = QString::fromLocal8Bit(proc->readAllStandardOutput());
-    appendColored(data.trimmed(), Qt::black);
+    const QString output = stdoutDecoder(proc->readAllStandardOutput());
+    appendProcessText(output, false);
 }
 
 void PostWindow::handleStderr()
 {
-    QString data = QString::fromLocal8Bit(proc->readAllStandardError());
-    appendColored(data.trimmed(), Qt::red);
+    const QString output = stderrDecoder(proc->readAllStandardError());
+    appendProcessText(output, true);
 }
 
 void PostWindow::increaseFont()
@@ -152,6 +229,7 @@ void PostWindow::decreaseFont()
 void PostWindow::clearOutput()
 {
     textEdit->clear();
+    stderrRanges.clear();
 }
 
 void PostWindow::termProcess()

--- a/LASSIE/src/windows/PostWindow.hpp
+++ b/LASSIE/src/windows/PostWindow.hpp
@@ -5,6 +5,8 @@
 #include <QToolBar>
 #include <QAction>
 #include <QProcess>
+#include <QStringDecoder>
+#include <QVector>
 
 class PostWindow : public QWidget
 {
@@ -23,11 +25,22 @@ private slots:
     void runProcess();
 
 private:
+    struct TextRange {
+        int start;
+        int end;
+    };
+
     QTextEdit *textEdit;
     QProcess *proc;
     bool autoscroll = true;
+    QStringDecoder stdoutDecoder{QStringDecoder::Utf8};
+    QStringDecoder stderrDecoder{QStringDecoder::Utf8};
+    QVector<TextRange> stderrRanges;
 
     void closeEvent(QCloseEvent*);
     void appendColored(const QString &text, const QColor &color);
+    void appendProcessText(const QString &text, bool fromStderr);
+    void recolorStderr(const QColor &color);
+    void resetProcessOutputState();
     void scrollToBottom();
 };


### PR DESCRIPTION
- Keep notation modifiers attached to individual pitches when simultaneous notes are rendered as a chord.
- Save and restore modifier selections independently for each Note event.
- Suppress irrelevant Particel warnings when its output is disabled.
- Improve process output handling, including UTF-8 decoding, error coloring, and exit-status propagation.


Closes #111.