### PR TITLE
Fix #67: env window: explainer text gets cut off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ include(DISSCOVersions.txt)
 
 project(DISSCO VERSION ${DISSCO_VERSION})
 
+include(CTest)
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     find_program(LLD_LINKER ld.lld)
     if(LLD_LINKER)

--- a/LASSIE/CMakeLists.txt
+++ b/LASSIE/CMakeLists.txt
@@ -177,4 +177,15 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_definitions(LASSIE PRIVATE QT_NO_DEBUG_OUTPUT)
 endif()
 
+if(BUILD_TESTING)
+    target_compile_definitions(LASSIE PRIVATE DISSCO_ENABLE_UI_LAYOUT_TESTS)
+    add_test(NAME LASSIE.EnvelopeLegendLayout
+        COMMAND LASSIE
+    )
+    set_tests_properties(LASSIE.EnvelopeLegendLayout PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen;DISSCO_TEST_ENVELOPE_LAYOUT=1"
+        TIMEOUT 10
+    )
+endif()
+
 message(STATUS "DONE!")

--- a/LASSIE/src/main.cpp
+++ b/LASSIE/src/main.cpp
@@ -2,6 +2,12 @@
 
 #include <QApplication>
 #include <QFile>
+#ifdef DISSCO_ENABLE_UI_LAYOUT_TESTS
+#include <QDebug>
+#include <QLabel>
+#include <QLayout>
+#include "windows/EnvelopeLibraryWindow.hpp"
+#endif
 #include "widgets/TextOverflowDisplayPolicy.hpp"
 #include "windows/MainWindow.hpp"
 
@@ -18,6 +24,42 @@ int main(int argc, char *argv[])
 
     QApplication a(argc, argv);
     TextOverflowDisplayPolicy textOverflowDisplayPolicy(a);
+
+#ifdef DISSCO_ENABLE_UI_LAYOUT_TESTS
+    if (qEnvironmentVariableIsSet("DISSCO_TEST_ENVELOPE_LAYOUT")) {
+        EnvelopeLibraryWindow window;
+        window.ensurePolished();
+        window.show();
+        for (int i = 0; i < 3; ++i) {
+            window.centralWidget()->layout()->activate();
+            QApplication::processEvents();
+        }
+
+        QLabel* legend = window.findChild<QLabel*>("envelopeLegend");
+        if (!legend) {
+            qCritical() << "Envelope legend was not found";
+            return 1;
+        }
+
+        const QRect legendInCentral(
+            legend->mapTo(window.centralWidget(), QPoint()), legend->size());
+        const int requiredHeight = legend->heightForWidth(legend->width());
+        const bool fullyVisible =
+            window.centralWidget()->rect().contains(legendInCentral)
+            && legend->visibleRegion().contains(legend->rect())
+            && legend->height() >= requiredHeight;
+
+        if (!fullyVisible) {
+            qCritical() << "Envelope legend is clipped:"
+                        << "actual" << legend->size()
+                        << "required height" << requiredHeight
+                        << "visible region" << legend->visibleRegion();
+        }
+
+        return fullyVisible ? 0 : 1;
+    }
+#endif
+
     registerAllFunctions();
     Inst *m = Inst::instance();
     MainWindow *w = new MainWindow(m);

--- a/LASSIE/src/windows/EnvelopeLibraryWindow.cpp
+++ b/LASSIE/src/windows/EnvelopeLibraryWindow.cpp
@@ -17,7 +17,6 @@
 #include <QPushButton>
 #include <QHBoxLayout>
 #include <QFormLayout>
-#include <QSizePolicy>
 #include <QDebug>
 
 #include "../utilities.hpp"
@@ -31,7 +30,7 @@ EnvelopeLibraryWindow::EnvelopeLibraryWindow(QWidget* parent)
 {
     // Window setup
     setWindowTitle("Envelope Library");
-    resize(600, 220); // Compact initial size
+    resize(600, 500);
 
     // Central widget and layout
     QWidget* central = new QWidget(this);
@@ -84,8 +83,9 @@ EnvelopeLibraryWindow::EnvelopeLibraryWindow(QWidget* parent)
     xyWidget->setLayout(xyForm);
     xyLegendLayout->addWidget(xyWidget, 0, Qt::AlignLeft);
     QLabel* legend = new QLabel("Right click the graph to see available actions or click-and-drag a node to adjust the envelope.\nThick segment = Flexible; Thin segment = Fixed.\nBlue = Linear; Green = Spline; Red = Exponential (curved).\nYou can also type X and Y values directly to position nodes.", this);
+    legend->setObjectName("envelopeLegend");
     legend->setWordWrap(true);
-    legend->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    // Keep QLabel's height-for-width policy so wrapped text gets enough room.
     xyLegendLayout->addWidget(legend, 1);
     layout->addLayout(xyLegendLayout);
 
@@ -356,4 +356,4 @@ void EnvelopeLibraryWindow::setEntries(const QString& x, const QString& y)
     // Reconnect signals
     connect(xEntry, &QLineEdit::textChanged, this, &EnvelopeLibraryWindow::valueEntriesChanged);
     connect(yEntry, &QLineEdit::textChanged, this, &EnvelopeLibraryWindow::valueEntriesChanged);
-} 
+}


### PR DESCRIPTION
Fixes #67 by preserving the envelope legend label’s height-for-width behavior and increasing the initial window height so all explainer text remains visible.

Adds a headless layout regression test to prevent future clipping.